### PR TITLE
Support for Modular Agentless Scanning for Volume access (single)

### DIFF
--- a/modules/agentless-scanning/README.md
+++ b/modules/agentless-scanning/README.md
@@ -1,0 +1,89 @@
+# AWS Agentless Scanning Module
+
+This module is used for Volume Access integration in AWS. It creates the resources required to perform agentless EC2 host scanning.
+
+The following resources will be created in each instrumented account through CloudFormation StackSet in provided regions:
+- An `IAM Role` and associated `policies` that allows Sysdig to perform tasks necessary for agentless scanning.
+- A `KMS key` used to transcript volume snapshots in the each region. `Alias` for this key in each region.
+
+When run in Organizational mode, this module will be deployed via CloudFormation StackSets that should be created in the management account. They will create the above resources in each account in the organization, and automatically in any member accounts that are later added to the organization. If a delegated admin account is used, only SERVICE_MANAGED stacksets will be created in the delegated admin account, responsible for creating the above resources in each account in the organization.
+
+This module will also deploy a Trusted Role Component and a Crypto Key Component in Sysdig Backend for onboarded Sysdig Cloud Account.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.60.0 |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.60.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [random_id.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_iam_role.scanning_stackset_admin_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.scanning_stackset_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_policy.scanning_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.scanning_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_policy_attachment.scanning_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_cloudformation_stack_set.primary_acc_stackset](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
+| [aws_cloudformation_stack_set_instance.primary_acc_stackset_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
+| [sysdig_secure_cloud_auth_account_component.aws_scanning_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_auth_account_component) | resource |
+| [sysdig_secure_cloud_auth_account_component.aws_crypto_key](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_auth_account_component) | resource |
+| [aws_iam_policy_document.scanning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.scanning_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
+| [sysdig_secure_trusted_cloud_identity.trusted_identity](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_trusted_cloud_identity) | data source |
+| [sysdig_secure_tenant_external_id.external_id](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_tenant_external_id) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_failure_tolerance_percentage"></a> [failure\_tolerance\_percentage](#input\_failure\_tolerance\_percentage) | The percentage of accounts, per Region, for which stack operations can fail before AWS CloudFormation stops the operation in that Region | `number` | `90` | no |
+| <a name="input_is_organizational"></a> [is\_organizational](#input\_is\_organizational) | (Optional) Set this field to 'true' to deploy Agentless Scanning to an AWS Organization (Or specific OUs) | `bool` | `false` | no |
+| <a name="input_kms_key_deletion_window"></a> [kms\_key\_deletion\_window](#input\_kms\_key\_deletion\_window) | Deletion window for shared KMS key | `number` | `7` | no |
+| <a name="input_mgt_stackset"></a> [mgt\_stackset](#input\_mgt\_stackset) | (Optional) Indicates if the management stackset should be deployed | `bool` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the installation. Assigned to most child resource(s) | `string` | `"sysdig-secure-scanning"` | no |
+| <a name="input_org_units"></a> [org\_units](#input\_org\_units) | (Optional) List of Organization Unit IDs in which to setup Agentless Scanning. By default, Agentless Scanning will be setup in all accounts within the Organization. This field is ignored if `is_organizational = false` | `set(string)` | `[]` | no |
+| <a name="input_regions"></a> [regions](#input\_regions) | (Optional) List of regions in which to install Agentless Scanning | `set(string)` | `[]` | no |
+| <a name="input_scanning_account_id"></a> [scanning\_account\_id](#input\_scanning\_account\_id) | The identifier of the account that will receive volume snapshots | `string` | `"878070807337"` | no |
+| <a name="input_stackset_admin_role_arn"></a> [stackset\_admin\_role\_arn](#input\_stackset\_admin\_role\_arn) | (Optional) stackset admin role to run SELF\_MANAGED stackset | `string` | `""` | no |
+| <a name="input_stackset_execution_role_name"></a> [stackset\_execution\_role\_name](#input\_stackset\_execution\_role\_name) | (Optional) stackset execution role name to run SELF\_MANAGED stackset | `string` | `""` | no |
+| <a name="auto_create_stackset_roles"></a> [auto\_create\_stackset\_roles](#input\_auto\_create\_stackset\_roles) | Whether to auto create the custom stackset roles to run SELF_MANAGED stackset | `bool` | `true` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
+| <a name="delegated_admin"></a> [delegated_admin](#input\_delegated\_admin) | Whether to create the resources using an delegated admin account | `bool` | `false` | no |
+| <a name="input_sysdig_secure_account_id"></a> [sysdig\_secure\_account\_id](#input\_sysdig\_secure\_account\_id) | ID of the Sysdig Cloud Account to enable Agentless Scanning for (incase of organization, ID of the Sysdig management account) | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_scanning_role_component_id"></a> [scanning\_role\_component\_id](#output\_scanning\_role\_component\_id) | Component identifier of scanning role created in Sysdig Backend for Agentless Scanning |
+| <a name="output_crypto_key_component_id"></a> [crypto\_key\_component\_id](#output\_crypto\_key\_component\_id) | Component identifier of KMS crypto key created in Sysdig Backend for Agentless Scanning |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Authors
+
+Module is maintained by [Sysdig](https://sysdig.com).
+
+## License
+
+Apache 2 Licensed. See LICENSE for full details.

--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -1,0 +1,494 @@
+##################################
+# Controller IAM roles and stuff #
+##################################
+
+#-----------------------------------------------------------------------------------------------------------------------------------------
+# For both Single Account and Organizational installs, resources are created using CloudFormation StackSet.
+# For Organizational installs, see organizational.tf.
+#
+# For single installs, the resources in this file are used to instrument the singleton account, whether it is a management account or a
+# member account. (delegated admin account is a noop here for single installs)
+#
+# For organizational installs, resources in this file get created for management account only. (because service-managed stacksets do not
+# include the management account they are created in, even if this account is within the target Organization).
+# If a delegated admin account is used instead (determined via delegated_admin flag), resources will skip creation. This is because we
+# don't want to create these stacksets if user provides a delegated admin account instead of management account. (because service-managed
+# stacksets include the delegated admin account already)
+#-----------------------------------------------------------------------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------------------
+# Fetch the data sources
+#-----------------------------------------------------------------------------------------
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+  // Get the source role ARN from the currently assumed session role
+  arn = data.aws_caller_identity.current.arn
+}
+
+data "sysdig_secure_agentless_scanning_assets" "assets" {}
+
+data "sysdig_secure_trusted_cloud_identity" "trusted_identity" {
+	cloud_provider = "aws"
+}
+
+data "sysdig_secure_tenant_external_id" "external_id" {}
+
+#-----------------------------------------------------------------------------------------
+# These locals indicate the provider account inormation and the region list passed.
+#-----------------------------------------------------------------------------------------
+locals {
+  region_set = toset(var.regions)
+  account_id = data.aws_caller_identity.current.account_id
+  caller_arn = data.aws_iam_session_context.current.issuer_arn
+}
+
+#-----------------------------------------------------------------------------------------
+# Generate a unique name for resources using random suffix and account ID hash
+#-----------------------------------------------------------------------------------------
+locals {
+  account_id_hash        = substr(md5(local.account_id), 0, 4)
+  scanning_resource_name = "${var.name}-${random_id.suffix.hex}-${local.account_id_hash}"
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# A random resource is used to generate unique name suffix for scanning resources.
+# This prevents conflicts when recreating scanning resources with the same name.
+#-----------------------------------------------------------------------------------------------------------------------
+resource "random_id" "suffix" {
+  byte_length = 3
+}
+
+#-----------------------------------------------------------------------------------------------------------------------------------------
+# Self-managed stacksets require pair of StackSetAdministrationRole & StackSetExecutionRole IAM roles with self-managed permissions.
+#
+# If auto_create_stackset_roles is true, terraform will create this IAM Admin role in the source account with permissions to create
+# stacksets. If false, and values for stackset Admin role ARN is provided stackset will use it, else AWS will look for
+# predefined/default AWSCloudFormationStackSetAdministrationRole.
+#-----------------------------------------------------------------------------------------------------------------------------------------
+
+# IAM Policy Document used by Stackset roles for the KMS operations policy
+data "aws_iam_policy_document" "kms_operations" {
+  count = !var.auto_create_stackset_roles ? 0 : 1
+
+  statement {
+    sid = "KmsOperationsAccess"
+    effect = "Allow"
+    actions = [
+      "kms:*",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "scanning_stackset_admin_role" {
+  count = !var.auto_create_stackset_roles ? 0 : 1
+  name  = "AWSCloudFormationStackSetAdministrationRoleForScanning"
+  tags  = var.tags
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "cloudformation.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"]
+  inline_policy {
+    name   = "KmsOperationsAccess"
+    policy = data.aws_iam_policy_document.kms_operations[0].json
+  }
+}
+
+#-----------------------------------------------------------------------------------------------------------------------------------------
+# Self-managed stacksets require pair of StackSetAdministrationRole & StackSetExecutionRole IAM roles with self-managed permissions.
+#
+# If auto_create_stackset_roles is true, terraform will create this IAM Admin role in the source account with permissions to create
+# stacksets, Scanning resources and trust relationship to CloudFormation service. If false, and values for stackset Execution role
+# name is provided stackset will use it, else AWS will look for predefined/default AWSCloudFormationStackSetExecutionRole.
+#-----------------------------------------------------------------------------------------------------------------------------------------
+
+resource "aws_iam_role" "scanning_stackset_execution_role" {
+  count = !var.auto_create_stackset_roles ? 0 : 1
+  name  = "AWSCloudFormationStackSetExecutionRoleForScanning"
+  tags  = var.tags
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "AWS": "arn:aws:iam::${local.account_id}:role/${aws_iam_role.scanning_stackset_admin_role[0].name}"
+      },
+      "Effect": "Allow",
+      "Condition": {}
+    }
+  ]
+}
+EOF
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
+  ]
+  inline_policy {
+    name   = "KmsOperationsAccess"
+    policy = data.aws_iam_policy_document.kms_operations[0].json
+  }
+}
+
+#-----------------------------------------------------------------------------------------------------------------------------------------
+# These resources create a custom Agentless Scanning IAM Policy in the source account, referring a custom IAM Policy Document defining
+# the respective permissions for scanning.
+#-----------------------------------------------------------------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "scanning" {
+  # General read permission, necessary for the discovery phase.
+  statement {
+    sid = "Read"
+
+    actions = [
+      "ec2:Describe*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  # Allow the listing of KMS keys, necessary to find the right one.
+  statement {
+    sid = "AllowKMSKeysListing"
+
+    actions = [
+      "kms:ListKeys",
+      "kms:ListAliases",
+      "kms:ListResourceTags",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid = "AllowKMSEncryptDecrypt"
+
+    actions = [
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:CreateGrant",
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+      values = [
+        "ec2.*.amazonaws.com",
+      ]
+    }
+  }
+
+  # Allows the creation of snapshots.
+  statement {
+    sid = "CreateTaggedSnapshotFromVolume"
+
+    actions = [
+      "ec2:CreateSnapshot",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  # Allows the copy of snapshot, which is necessary for re-encrypting
+  # them to make them shareable with Sysdig account.
+  statement {
+    sid = "CopySnapshots"
+
+    actions = [
+      "ec2:CopySnapshot",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  # Allows tagging snapshots only for specific tag key and value.
+  statement {
+    sid = "SnapshotTags"
+
+    actions = [
+      "ec2:CreateTags"
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    # This condition limits the scope of tagging to the sole
+    # CreateSnapshot and CopySnapshot operations.
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:CreateAction"
+      values = [
+        "CreateSnapshot",
+        "CopySnapshot",
+      ]
+    }
+
+    # This condition limits the value of CreatedBy tag to the exact
+    # string Sysdig.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/CreatedBy"
+      values   = ["Sysdig"]
+    }
+  }
+
+  # This statement allows the modification of those snapshot that have
+  # a simple "CreatedBy" tag valued "Sysdig". Additionally, such
+  # snapshots can only be shared with a specific AWS account, namely
+  # Sysdig account.
+  statement {
+    sid = "ec2SnapshotShare"
+
+    actions = [
+      "ec2:ModifySnapshotAttribute",
+    ]
+
+    condition {
+      test     = "StringEqualsIgnoreCase"
+      variable = "aws:ResourceTag/CreatedBy"
+      values   = ["Sysdig"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:Add/userId"
+      values = [
+        data.sysdig_secure_agentless_scanning_assets.assets.aws.account_id
+      ]
+    }
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid = "ec2SnapshotDelete"
+
+    actions = [
+      "ec2:DeleteSnapshot",
+    ]
+
+    condition {
+      test     = "StringEqualsIgnoreCase"
+      variable = "aws:ResourceTag/CreatedBy"
+      values   = ["Sysdig"]
+    }
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "scanning_policy" {
+  name        = local.scanning_resource_name
+  description = "Grants Sysdig Secure access to volumes and snapshots"
+  policy      = data.aws_iam_policy_document.scanning.json
+  tags        = var.tags
+}
+
+#-----------------------------------------------------------------------------------------------------------------------------------------
+# These resources create an Assume Role IAM Policy Document, allowing Sysdig to assume role to run scanning.
+#-----------------------------------------------------------------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "scanning_assume_role_policy" {
+
+  statement {
+    sid = "SysdigSecureScanning"
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity,
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [data.sysdig_secure_tenant_external_id.external_id.external_id]
+    }
+  }
+}
+
+#-----------------------------------------------------------------------------------------------------------------------------------------
+# These resources create an Agentless Scanning IAM Role in the source account, with the Assume Role IAM Policy and
+# custom Agentless Scanning IAM Policy attached.
+#-----------------------------------------------------------------------------------------------------------------------------------------
+
+resource "aws_iam_role" "scanning_role" {
+  name               = local.scanning_resource_name
+  tags               = var.tags
+  assume_role_policy = data.aws_iam_policy_document.scanning_assume_role_policy.json
+}
+
+resource "aws_iam_policy_attachment" "scanning_policy_attachment" {
+  name       = local.scanning_resource_name
+  roles      = [aws_iam_role.scanning_role.name]
+  policy_arn = aws_iam_policy.scanning_policy.arn
+}
+
+#-----------------------------------------------------------------------------------------------------------------------------------------
+# This resource creates a stackset and stackset instance to deploy resources for agentless scanning in the source account :-
+#   - KMS Primary Key, and
+#   - KMS Primary alias
+#
+# Note: self-managed stacksets require pair of StackSetAdministrationRole & StackSetExecutionRole IAM roles with self-managed permissions 
+#-----------------------------------------------------------------------------------------------------------------------------------------
+
+resource "aws_cloudformation_stack_set" "primary_acc_stackset" {
+  name                    = join("-", [local.scanning_resource_name, "ScanningKmsPrimaryAcc"])
+  tags                    = var.tags
+  permission_model        = "SELF_MANAGED"
+  capabilities            = ["CAPABILITY_NAMED_IAM"]
+  administration_role_arn = var.auto_create_stackset_roles ? aws_iam_role.scanning_stackset_admin_role[0].arn : var.stackset_admin_role_arn
+  execution_role_name     = var.auto_create_stackset_roles ? aws_iam_role.scanning_stackset_execution_role[0].name : var.stackset_execution_role_name
+
+  managed_execution {
+    active = true
+  }
+
+  lifecycle {
+    ignore_changes = [administration_role_arn]
+  }
+
+  template_body = <<TEMPLATE
+Resources:
+  AgentlessScanningKmsPrimaryKey:
+      Type: AWS::KMS::Key
+      Properties:
+        Description: "Sysdig Agentless Scanning encryption key"
+        PendingWindowInDays: ${var.kms_key_deletion_window}
+        KeyUsage: "ENCRYPT_DECRYPT"
+        KeyPolicy:
+          Id: ${local.scanning_resource_name}
+          Statement:
+            - Sid: "SysdigAllowKms"
+              Effect: "Allow"
+              Principal:
+                AWS: ["arn:aws:iam::${data.sysdig_secure_agentless_scanning_assets.assets.aws.account_id}:root", !Sub "arn:aws:iam::$${AWS::AccountId}:role/${local.scanning_resource_name}"]
+              Action:
+                - "kms:Encrypt"
+                - "kms:Decrypt"
+                - "kms:ReEncrypt*"
+                - "kms:GenerateDataKey*"
+                - "kms:DescribeKey"
+                - "kms:CreateGrant"
+                - "kms:ListGrants"
+              Resource: "*"
+            - Sid: "AllowCustomerManagement"
+              Effect: "Allow"
+              Principal:
+                AWS: ["arn:aws:iam::${local.account_id}:root", "${local.caller_arn}"]
+              Action: "kms:*"
+              Resource: "*"
+  AgentlessScanningKmsPrimaryAlias:
+      Type: AWS::KMS::Alias
+      Properties:
+        AliasName: "alias/${local.scanning_resource_name}"
+        TargetKeyId: !Ref AgentlessScanningKmsPrimaryKey
+
+TEMPLATE
+
+  depends_on = [
+    aws_iam_role.scanning_role,
+    aws_iam_role.scanning_stackset_admin_role,
+    aws_iam_role.scanning_stackset_execution_role
+  ]
+}
+
+# stackset instance to deploy resources for agentless scanning, in all regions of given account
+resource "aws_cloudformation_stack_set_instance" "primary_acc_stackset_instance" {
+  for_each = local.region_set
+  region   = each.key
+
+  stack_set_name = aws_cloudformation_stack_set.primary_acc_stackset.name
+  operation_preferences {
+    max_concurrent_percentage    = 100
+    failure_tolerance_percentage = var.failure_tolerance_percentage
+    concurrency_mode             = "SOFT_FAILURE_TOLERANCE"
+    region_concurrency_type      = "PARALLEL"
+  }
+
+  timeouts {
+    create = var.timeout
+    update = var.timeout
+    delete = var.timeout
+  }
+}
+
+#-----------------------------------------------------------------------------------------------------------------
+# Call Sysdig Backend to add the trusted role for Agentless Scanning to the Sysdig Cloud Account
+#
+# Note (optional): To ensure this gets called after all cloud resources are created, add
+# explicit dependency using depends_on
+#-----------------------------------------------------------------------------------------------------------------
+resource "sysdig_secure_cloud_auth_account_component" "aws_scanning_role" {
+  account_id                 = var.sysdig_secure_account_id
+  type                       = "COMPONENT_TRUSTED_ROLE"
+  instance                   = "secure-scanning"
+  version                    = "v0.1.0"
+  trusted_role_metadata = jsonencode({
+    aws = {
+      role_name = local.scanning_resource_name
+    }
+  })
+}
+
+#-----------------------------------------------------------------------------------------------------------------
+# Call Sysdig Backend to add the KMS crypto key for Agentless Scanning to the Sysdig Cloud Account
+#
+# Note (optional): To ensure this gets called after all cloud resources are created, add
+# explicit dependency using depends_on
+#-----------------------------------------------------------------------------------------------------------------
+resource "sysdig_secure_cloud_auth_account_component" "aws_crypto_key" {
+  account_id                 = var.sysdig_secure_account_id
+  type                       = "COMPONENT_CRYPTO_KEY"
+  instance                   = "secure-scanning"
+  version                    = "v0.1.0"
+  crypto_key_metadata = jsonencode({
+    aws = {
+      kms = {
+          alias   = "alias/${local.scanning_resource_name}"
+          regions = var.regions
+        }
+    }
+  })
+}

--- a/modules/agentless-scanning/outputs.tf
+++ b/modules/agentless-scanning/outputs.tf
@@ -1,0 +1,11 @@
+output "scanning_role_component_id" {
+  value       = "${sysdig_secure_cloud_auth_account_component.aws_scanning_role.type}/${sysdig_secure_cloud_auth_account_component.aws_scanning_role.instance}"
+  description = "Component identifier of scanning role created in Sysdig Backend for Agentless Scanning"
+  depends_on = [ sysdig_secure_cloud_auth_account_component.aws_scanning_role ]
+}
+
+output "crypto_key_component_id" {
+  value       = "${sysdig_secure_cloud_auth_account_component.aws_crypto_key.type}/${sysdig_secure_cloud_auth_account_component.aws_crypto_key.instance}"
+  description = "Component identifier of KMS crypto key created in Sysdig Backend for Agentless Scanning"
+  depends_on = [ sysdig_secure_cloud_auth_account_component.aws_crypto_key ]
+}

--- a/modules/agentless-scanning/variables.tf
+++ b/modules/agentless-scanning/variables.tf
@@ -1,0 +1,90 @@
+variable "scanning_account_id" {
+  type        = string
+  description = "The identifier of the account that will receive volume snapshots"
+  default     = "878070807337"
+}
+
+variable "kms_key_deletion_window" {
+  description = "Deletion window for shared KMS key"
+  type        = number
+  default     = 7
+}
+
+variable "name" {
+  description = "The name of the installation. Assigned to most child resource(s)"
+  type        = string
+  default     = "sysdig-secure-scanning"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
+  default = {
+    "product" = "sysdig-secure-for-cloud"
+  }
+}
+
+variable "is_organizational" {
+  description = "(Optional) Set this field to 'true' to deploy Agentless Scanning to an AWS Organization (Or specific OUs)"
+  type        = bool
+  default     = false
+}
+
+variable "org_units" {
+  description = "(Optional) List of Organization Unit IDs in which to setup Agentless Scanning. By default, Agentless Scanning will be setup in all accounts within the Organization. This field is ignored if `is_organizational = false`"
+  type        = set(string)
+  default     = []
+}
+
+variable "regions" {
+  description = "(Optional) List of regions in which to install Agentless Scanning"
+  type        = set(string)
+  default     = []
+}
+
+variable "auto_create_stackset_roles" {
+  description = "Whether to auto create the custom stackset roles to run SELF_MANAGED stackset. Default is true"
+  type        = bool
+  default     = true
+}
+
+variable "stackset_admin_role_arn" {
+  description = "(Optional) stackset admin role to run SELF_MANAGED stackset"
+  type        = string
+  default     = ""
+}
+
+variable "stackset_execution_role_name" {
+  description = "(Optional) stackset execution role name to run SELF_MANAGED stackset"
+    type        = string
+    default     = ""
+}
+
+variable "timeout" {
+  type        = string
+  description = "Default timeout values for create, update, and delete operations"
+  default     = "30m"
+}
+
+variable "mgt_stackset" {
+  description = "(Optional) Indicates if the management stackset should be deployed"
+  type        = bool
+  default     = true
+}
+
+variable "failure_tolerance_percentage" {
+  type        = number
+  description = "The percentage of accounts, per Region, for which stack operations can fail before AWS CloudFormation stops the operation in that Region"
+  default     = 90
+}
+
+variable "delegated_admin" {
+  description = "Whether a delegated admin account will be used"
+  type        = bool
+  default     = false
+}
+
+variable "sysdig_secure_account_id" {
+  type        = string
+  description = "ID of the Sysdig Cloud Account to enable Agentless Scanning for (incase of organization, ID of the Sysdig management account)"
+}

--- a/modules/agentless-scanning/versions.tf
+++ b/modules/agentless-scanning/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.2.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.60.0"
+    }
+    sysdig = {
+      source  = "sysdiglabs/sysdig"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1"
+    }
+  }
+}

--- a/test/examples/single_account/agentless_scanning.tf
+++ b/test/examples/single_account/agentless_scanning.tf
@@ -1,0 +1,18 @@
+#---------------------------------------------------------------------------------------------
+# Ensure installation flow for foundational onboarding has been completed before
+# installing additional Sysdig features.
+#---------------------------------------------------------------------------------------------
+
+module "agentless-scanning" {
+  source                   = "../../../modules/agentless-scanning"
+  regions                  = ["us-east-1", "us-west-1", "us-west-2"]
+  sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
+}
+
+resource "sysdig_secure_cloud_auth_account_feature" "agentless_scanning" {
+  account_id = module.onboarding.sysdig_secure_account_id
+  type       = "FEATURE_SECURE_AGENTLESS_SCANNING"
+  enabled    = true
+  components = [module.agentless-scanning.scanning_role_component_id, module.agentless-scanning.crypto_key_component_id]
+  depends_on = [ module.agentless-scanning ]
+}


### PR DESCRIPTION
Change summary:
--------------------
- Added the module as a feature independent module.
- Added the respective tf files for single onboarding case
- Added test example for agentless-scanning (single)

Testing:
---------
Validated the changes with single onboarding of :-
- actual account on AWS of type management.
- actual account on AWS, which is a non-admin/member account