### PR TITLE
Support for Modular Agentless Scanning for Volume access (org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,93 @@
-# terraform-aws-secure
+# Sysdig Secure for Cloud in AWS
+
+Terraform module that deploys the [**Sysdig Secure for Cloud** stack in **AWS**](https://docs.sysdig.com/en/docs/installation/sysdig-secure-for-cloud/deploy-sysdig-secure-for-cloud-on-aws).
+<br/>
+
+With Modular Onboarding, introducing the following design and install structure for `terraform-aws-secure`:
+
+* **[Onboarding]**: It onboards an AWS Account or Organization for the first time to Sysdig Secure for Cloud, and collects
+inventory and organizational hierarchy in the given AWS Organization. Managed through `onboarding` module. <br/>
+
+Provides unified threat-detection, compliance, forensics and analysis through these major components:
+
+* **[CSPM](https://docs.sysdig.com/en/docs/sysdig-secure/posture/)**: It evaluates periodically your cloud configuration, using Cloud Custodian, against some benchmarks and returns the results and remediation you need to fix. Managed through `config-posture` module. <br/>
+
+* **[CDR (Cloud Detection and Response)](https://docs.sysdig.com/en/docs/sysdig-secure/insights/)**: It sends periodically activity logs to Sysdig by directing those to a dedicated Event Bridge which will be queried by the Sysdig backend to retrieve the data for log ingestion. Enabled via `event-bridge` integrations module. <br/>
+
+* **[Vulnerability Management Agentless Scanning](https://docs.sysdig.com/en/docs/sysdig-secure/vulnerabilities/)**: It uses disk snapshots to provide highly accurate views of vulnerability risk, access to public exploits, and risk management.  Managed through `agentless-scanning` module. <br/>
+
+For other Cloud providers check: [GCP](https://github.com/draios/terraform-google-secure-for-cloud), [Azure](https://github.com/draios/terraform-azurerm-secure-for-cloud)
+
+<br/>
+
+## Modules
+
+### Feature modules
+
+These are independent feature modules which deploy and manage all the required Cloud resources and Sysdig resources
+for the respective Sysdig features. They manage both, onboarding a single AWS Account or an AWS Organization to Sysdig Secure for Cloud.
+
+`onboarding`, `config-posture` and `agentless-scanning` are independent feature modules.
+
+### Integrations
+
+The modules under `integrations` are feature agnostic modules which deploy and manage all the required Cloud resources and Sysdig resources
+for shared Sysdig integrations. That is to say, one or more Sysdig features can be enabled by installing an integration.
+
+These modules manage both, onboarding a single AWS Account or an AWS Organization to Sysdig Secure for Cloud.
+
+`event-bridge` is an integration module.
+
+## Examples and usage
+
+The modules in this repository can be installed on a single AWS account, or on an entire AWS Organization, or organizational units within the org.
+
+The `test` directory has sample `examples` for all these module deployments i.e under `single_account`,  or `organization` sub-folders.
+
+For example, to onboard a single AWS account, with CSPM enabled, with modular installation :-
+1. Run the terraform snippet under `test/examples/single_account/onboarding_with_posture.tf` with
+   the appropriate attribute values populated.
+2. This will install the `onboarding` module, which will also create a Cloud Account on Sysdig side.
+3. It will also install the `config-posture` module, which will also install cloud resources as well as Sysdig resources
+   for successfully running CSPM scans.
+4. On Sysdig side, you will be able to see the Cloud account onboarded with required components, and CSPM feature installed and enabled.
+
+To run this example you need have your [aws master-account profile configured in CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) and to execute:
+```terraform
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Notice that:
+* This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
+* All created resources will be created within the tags `product:sysdig-secure-for-cloud`, within the resource-group `sysdig-secure-for-cloud`
+
+<br/>
+
+## Best practices
+
+For contributing to existing modules or adding new modules, below are some of the best practices recommended :-
+* Module names referred and used in deployment snippets should be consistent with those in their source path.
+* A module can fall into one of two categories - feature module or an integrations module.
+* Every user-facing deployment snippet will,
+  - at the top level first call the feature module or integrations module from this repo. These modules deploy corresponding cloud resources and Sysdig component resources.
+  - the corresponding feature resource will be added as the last block and enabled from the module installed component resource reference.
+  See sample deployment snippets in `test/examples` for more.
+* integrations modules are shared and could enable multiple features. Hence, one should be careful with changes to them.
+* Module naming follows the pattern with "-" , resource and variable naming follows the pattern with "_".
+
+
+## Troubleshooting
+
+### Q: I'm not able to see Cloud Identity & Access Management (CIEM) results
+A: Make sure you installed both [onboarding](https://github.com/draios/terraform-aws-secure/tree/master/modules/onboarding) and [event-bridge](https://github.com/draios/terraform-aws-secure/tree/master/modules/integrations/event-bridge) modules
+
+
+## Authors
+
+Module is maintained and supported by [Sysdig](https://sysdig.com).
+
+## License
+
+Apache 2 Licensed. See LICENSE for full details.

--- a/modules/agentless-scanning/README.md
+++ b/modules/agentless-scanning/README.md
@@ -44,6 +44,10 @@ No modules.
 | [aws_cloudformation_stack_set_instance.primary_acc_stackset_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
 | [sysdig_secure_cloud_auth_account_component.aws_scanning_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_auth_account_component) | resource |
 | [sysdig_secure_cloud_auth_account_component.aws_crypto_key](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_auth_account_component) | resource |
+| [aws_cloudformation_stack_set.scanning_role_stackset](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
+| [aws_cloudformation_stack_set_instance.scanning_role_stackset_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
+| [aws_cloudformation_stack_set.ou_resources_stackset](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
+| [aws_cloudformation_stack_set_instance.ou_stackset_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
 | [aws_iam_policy_document.scanning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.scanning_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_operations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -51,6 +55,7 @@ No modules.
 | [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
 | [sysdig_secure_trusted_cloud_identity.trusted_identity](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_trusted_cloud_identity) | data source |
 | [sysdig_secure_tenant_external_id.external_id](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_tenant_external_id) | data source |
+| [aws_organizations_organization.org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs
 

--- a/modules/agentless-scanning/organizational.tf
+++ b/modules/agentless-scanning/organizational.tf
@@ -1,0 +1,249 @@
+#-----------------------------------------------------------------------------------------------------------------------
+# The resources in this file set up an Agentless Scanning IAM Role, Policies, KMS keys and KMS Aliases in all accounts
+# in an AWS Organization via service-managed CloudFormation StackSets. For a single account installation, see main.tf.
+# Global resources: IAM Role and Policy
+# Non-global / Regional resources:
+# - a KMS Primary key is created, in each region of region list,
+# - an Alias by the same name for the respective key, in each region of region list.
+#
+# If a delegated admin account is used (determined via delegated_admin flag), service-managed stacksets will be created
+# acting as delegated_admin to deploy resources in all acocunts within AWS Organization.
+#-----------------------------------------------------------------------------------------------------------------------
+
+data "aws_organizations_organization" "org" {
+  count = var.is_organizational ? 1 : 0
+}
+
+locals {
+  organizational_unit_ids = var.is_organizational && length(var.org_units) == 0 ? [for root in data.aws_organizations_organization.org[0].roots : root.id] : toset(var.org_units)
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# stackset and stackset instance deployed in organization units for Agentless Scanning IAM Role, Policies
+#-----------------------------------------------------------------------------------------------------------------------
+
+# stackset to deploy agentless scanning role in organization unit
+resource "aws_cloudformation_stack_set" "scanning_role_stackset" {
+  count = var.is_organizational ? 1 : 0
+
+  name             = join("-", [local.scanning_resource_name, "ScanningRoleOrg"])
+  tags             = var.tags
+  permission_model = "SERVICE_MANAGED"
+  capabilities     = ["CAPABILITY_NAMED_IAM"]
+
+  managed_execution {
+    active = true
+  }
+
+  auto_deployment {
+    enabled                          = true
+    retain_stacks_on_account_removal = false
+  }
+
+  lifecycle {
+    ignore_changes = [administration_role_arn]
+  }
+
+  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
+
+  template_body = <<TEMPLATE
+Resources:
+  AgentlessScanningRole:
+      Type: AWS::IAM::Role
+      Properties:
+        RoleName: ${local.scanning_resource_name}
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Sid: "SysdigSecureScanning"
+              Effect: "Allow"
+              Action: "sts:AssumeRole"
+              Principal:
+                AWS: "${data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity}"
+              Condition:
+                StringEquals:
+                  sts:ExternalId: "${data.sysdig_secure_tenant_external_id.external_id.external_id}"
+        Policies:
+          - PolicyName: ${local.scanning_resource_name}
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Sid: "Read"
+                  Effect: "Allow"
+                  Action: "ec2:Describe*"
+                  Resource: "*"
+                - Sid: "AllowKMSKeysListing"
+                  Effect: "Allow"
+                  Action:
+                    - "kms:ListKeys"
+                    - "kms:ListAliases"
+                    - "kms:ListResourceTags"
+                  Resource: "*"
+                - Sid: "AllowKMSEncryptDecrypt"
+                  Effect: "Allow"
+                  Action:
+                    - "kms:DescribeKey"
+                    - "kms:Encrypt"
+                    - "kms:Decrypt"
+                    - "kms:ReEncrypt*"
+                    - "kms:GenerateDataKey*"
+                    - "kms:CreateGrant"
+                  Resource: "*"
+                  Condition:
+                    StringLike:
+                      kms:ViaService: ["ec2.*.amazonaws.com"]
+                - Sid: "CreateTaggedSnapshotFromVolume"
+                  Effect: "Allow"
+                  Action: "ec2:CreateSnapshot"
+                  Resource: "*"
+                - Sid: "CopySnapshots"
+                  Effect: "Allow"
+                  Action: "ec2:CopySnapshot"
+                  Resource: "*"
+                - Sid: "SnapshotTags"
+                  Effect: "Allow"
+                  Action: "ec2:CreateTags"
+                  Resource: "*"
+                  Condition:
+                    StringEquals:
+                      ec2:CreateAction: ["CreateSnapshot", "CopySnapshot"]
+                      aws:RequestTag/CreatedBy: "Sysdig"
+                - Sid: "ec2SnapshotShare"
+                  Effect: "Allow"
+                  Action: "ec2:ModifySnapshotAttribute"
+                  Resource: "*"
+                  Condition:
+                    StringEqualsIgnoreCase:
+                      aws:ResourceTag/CreatedBy: "Sysdig"
+                    StringEquals:
+                      ec2:Add/userId: "${data.sysdig_secure_agentless_scanning_assets.assets.aws.account_id}"
+                - Sid: "ec2SnapshotDelete"
+                  Effect: "Allow"
+                  Action: "ec2:DeleteSnapshot"
+                  Resource: "*"
+                  Condition:
+                    StringEqualsIgnoreCase:
+                      aws:ResourceTag/CreatedBy: "Sysdig"
+
+TEMPLATE
+}
+
+# stackset instance to deploy agentless scanning role, in all organization units
+resource "aws_cloudformation_stack_set_instance" "scanning_role_stackset_instance" {
+  count = var.is_organizational ? 1 : 0
+
+  stack_set_name = aws_cloudformation_stack_set.scanning_role_stackset[0].name
+  deployment_targets {
+    organizational_unit_ids = local.organizational_unit_ids
+  }
+  operation_preferences {
+    max_concurrent_percentage    = 100
+    failure_tolerance_percentage = var.failure_tolerance_percentage
+    concurrency_mode             = "SOFT_FAILURE_TOLERANCE"
+    # Roles are not regional and hence do not need regional parallelism
+  }
+
+  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
+
+  timeouts {
+    create = var.timeout
+    update = var.timeout
+    delete = var.timeout
+  }
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# stackset and stackset instance deployed for all accounts in all organization units
+#   - KMS Primary Key, and
+#   - KMS Primary alias
+#-----------------------------------------------------------------------------------------------------------------------
+
+# stackset to deploy resources for agentless scanning in organization unit
+resource "aws_cloudformation_stack_set" "ou_resources_stackset" {
+  count = var.is_organizational ? 1 : 0
+
+  name             = join("-", [local.scanning_resource_name, "ScanningKmsOrg"])
+  tags             = var.tags
+  permission_model = "SERVICE_MANAGED"
+  capabilities     = ["CAPABILITY_NAMED_IAM"]
+
+  managed_execution {
+    active = true
+  }
+
+  auto_deployment {
+    enabled                          = true
+    retain_stacks_on_account_removal = false
+  }
+
+  lifecycle {
+    ignore_changes = [administration_role_arn]
+  }
+
+  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
+
+  template_body = <<TEMPLATE
+Resources:
+  AgentlessScanningKmsPrimaryKey:
+      Type: AWS::KMS::Key
+      Properties:
+        Description: "Sysdig Agentless Scanning encryption key"
+        PendingWindowInDays: ${var.kms_key_deletion_window}
+        KeyUsage: "ENCRYPT_DECRYPT"
+        KeyPolicy:
+          Id: ${local.scanning_resource_name}
+          Statement:
+            - Sid: "SysdigAllowKms"
+              Effect: "Allow"
+              Principal:
+                AWS: ["arn:aws:iam::${data.sysdig_secure_agentless_scanning_assets.assets.aws.account_id}:root", !Sub "arn:aws:iam::$${AWS::AccountId}:role/${local.scanning_resource_name}"]
+              Action:
+                - "kms:Encrypt"
+                - "kms:Decrypt"
+                - "kms:ReEncrypt*"
+                - "kms:GenerateDataKey*"
+                - "kms:DescribeKey"
+                - "kms:CreateGrant"
+                - "kms:ListGrants"
+              Resource: "*"
+            - Sid: "AllowCustomerManagement"
+              Effect: "Allow"
+              Principal:
+                AWS: [!Sub "arn:aws:iam::$${AWS::AccountId}:root", "${local.caller_arn}"]
+              Action:
+                - "kms:*"
+              Resource: "*"
+  AgentlessScanningKmsPrimaryAlias:
+      Type: AWS::KMS::Alias
+      Properties:
+        AliasName: "alias/${local.scanning_resource_name}"
+        TargetKeyId: !Ref AgentlessScanningKmsPrimaryKey
+
+TEMPLATE
+}
+
+# stackset instance to deploy resources for agentless scanning, in all regions of each account in all organization units
+resource "aws_cloudformation_stack_set_instance" "ou_stackset_instance" {
+  depends_on = [aws_cloudformation_stack_set_instance.scanning_role_stackset_instance]
+  for_each   = var.is_organizational ? local.region_set : toset([])
+  region     = each.key
+
+  stack_set_name = aws_cloudformation_stack_set.ou_resources_stackset[0].name
+  deployment_targets {
+    organizational_unit_ids = local.organizational_unit_ids
+  }
+  operation_preferences {
+    max_concurrent_percentage    = 100
+    failure_tolerance_percentage = var.failure_tolerance_percentage
+    concurrency_mode             = "SOFT_FAILURE_TOLERANCE"
+    region_concurrency_type      = "PARALLEL"
+  }
+
+  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
+
+  timeouts {
+    create = var.timeout
+    update = var.timeout
+    delete = var.timeout
+  }
+}

--- a/test/examples/organization/agentless_scanning.tf
+++ b/test/examples/organization/agentless_scanning.tf
@@ -1,0 +1,20 @@
+#---------------------------------------------------------------------------------------------
+# Ensure installation flow for foundational onboarding has been completed before
+# installing additional Sysdig features.
+#---------------------------------------------------------------------------------------------
+
+module "agentless-scanning" {
+  source                   = "../../../modules/agentless-scanning"
+  regions                  = ["us-east-1", "us-west-1", "us-west-2"]
+  sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
+  is_organizational        = module.onboarding.is_organizational
+  org_units                = module.onboarding.organizational_unit_ids
+}
+
+resource "sysdig_secure_cloud_auth_account_feature" "agentless_scanning" {
+  account_id = module.onboarding.sysdig_secure_account_id
+  type       = "FEATURE_SECURE_AGENTLESS_SCANNING"
+  enabled    = true
+  components = [module.agentless-scanning.scanning_role_component_id, module.agentless-scanning.crypto_key_component_id]
+  depends_on = [ module.agentless-scanning ]
+}


### PR DESCRIPTION
Change summary:
----------------
- Added the respective tf file for Org onboarding case
- Added test example for scanning (org)
- Updated the self-managed stacksets during org onboarding to skip creation with delegated_admin conditional check
- Updated the README
- Added top-level README

Testing:
--------
Validated the changes with org onboarding of actual OU with mgmt account on AWS.