### PR TITLE
Remove component dependency of cspm role in CIEM

### DIFF
--- a/test/examples/organization/agentless_scanning.tf
+++ b/test/examples/organization/agentless_scanning.tf
@@ -16,5 +16,5 @@ resource "sysdig_secure_cloud_auth_account_feature" "agentless_scanning" {
   type       = "FEATURE_SECURE_AGENTLESS_SCANNING"
   enabled    = true
   components = [module.agentless-scanning.scanning_role_component_id, module.agentless-scanning.crypto_key_component_id]
-  depends_on = [ module.agentless-scanning ]
+  depends_on = [module.agentless-scanning]
 }

--- a/test/examples/organization/event_bridge.tf
+++ b/test/examples/organization/event_bridge.tf
@@ -16,13 +16,13 @@ resource "sysdig_secure_cloud_auth_account_feature" "threat_detection" {
   type       = "FEATURE_SECURE_THREAT_DETECTION"
   enabled    = true
   components = [module.event-bridge.event_bridge_component_id]
-  depends_on = [ module.event-bridge ]
+  depends_on = [module.event-bridge]
 }
 
 resource "sysdig_secure_cloud_auth_account_feature" "identity_entitlement" {
   account_id = module.onboarding.sysdig_secure_account_id
   type       = "FEATURE_SECURE_IDENTITY_ENTITLEMENT"
   enabled    = true
-  components = [module.config-posture.config_posture_component_id, module.event-bridge.event_bridge_component_id]
-  depends_on = [sysdig_secure_cloud_auth_account_feature.config_posture, sysdig_secure_cloud_auth_account_feature.threat_detection]
+  components = [module.event-bridge.event_bridge_component_id]
+  depends_on = [module.event-bridge, sysdig_secure_cloud_auth_account_feature.config_posture]
 }

--- a/test/examples/single_account/agentless_scanning.tf
+++ b/test/examples/single_account/agentless_scanning.tf
@@ -14,5 +14,5 @@ resource "sysdig_secure_cloud_auth_account_feature" "agentless_scanning" {
   type       = "FEATURE_SECURE_AGENTLESS_SCANNING"
   enabled    = true
   components = [module.agentless-scanning.scanning_role_component_id, module.agentless-scanning.crypto_key_component_id]
-  depends_on = [ module.agentless-scanning ]
+  depends_on = [module.agentless-scanning]
 }

--- a/test/examples/single_account/event_bridge.tf
+++ b/test/examples/single_account/event_bridge.tf
@@ -14,13 +14,13 @@ resource "sysdig_secure_cloud_auth_account_feature" "threat_detection" {
   type       = "FEATURE_SECURE_THREAT_DETECTION"
   enabled    = true
   components = [module.event-bridge.event_bridge_component_id]
-  depends_on = [ module.event-bridge ]
+  depends_on = [module.event-bridge]
 }
 
 resource "sysdig_secure_cloud_auth_account_feature" "identity_entitlement" {
   account_id = module.onboarding.sysdig_secure_account_id
   type       = "FEATURE_SECURE_IDENTITY_ENTITLEMENT"
   enabled    = true
-  components = [module.config-posture.config_posture_component_id, module.event-bridge.event_bridge_component_id]
-  depends_on = [sysdig_secure_cloud_auth_account_feature.config_posture, sysdig_secure_cloud_auth_account_feature.threat_detection]
+  components = [module.event-bridge.event_bridge_component_id]
+  depends_on = [module.event-bridge, sysdig_secure_cloud_auth_account_feature.config_posture]
 }


### PR DESCRIPTION
Fix summary:
-------------
1. Removing the component dependency of cspm's trusted role in ciem.
2. Keeping the feature dependency of CSPM in CIEM feature. This is because while CSPM feature will always be installed during foundational onboarding, while offboarding we need to ensure CIEM depends on the CSPM feature to offboard / be deleted.