### PR TITLE
Updating the test examples with user provided account ID

### DIFF
--- a/test/examples/organization/onboarding_with_cspm.tf
+++ b/test/examples/organization/onboarding_with_cspm.tf
@@ -13,7 +13,8 @@ provider "sysdig" {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region              = "us-east-1"
+  allowed_account_ids = ["123456789101"]
 }
 
 module "onboarding" {

--- a/test/examples/single_account/onboarding_with_cspm.tf
+++ b/test/examples/single_account/onboarding_with_cspm.tf
@@ -13,7 +13,8 @@ provider "sysdig" {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region              = "us-east-1"
+  allowed_account_ids = ["123456789101"]
 }
 
 module "onboarding" {


### PR DESCRIPTION
Fix summary:
-------------
We want to ensure that the account ID input is passed in the provider block, and used in the foundational modules.

Testing:
---------
Tested the various combinations of passed/allowed accountID in the provider with different authenticated accountID.