### PR TITLE
Cleanup partial support for delegated_admin

### DIFF
--- a/modules/agentless-scanning/README.md
+++ b/modules/agentless-scanning/README.md
@@ -6,7 +6,7 @@ The following resources will be created in each instrumented account through Clo
 - An `IAM Role` and associated `policies` that allows Sysdig to perform tasks necessary for agentless scanning.
 - A `KMS key` used to transcript volume snapshots in the each region. `Alias` for this key in each region.
 
-When run in Organizational mode, this module will be deployed via CloudFormation StackSets that should be created in the management account. They will create the above resources in each account in the organization, and automatically in any member accounts that are later added to the organization. If a delegated admin account is used, only SERVICE_MANAGED stacksets will be created in the delegated admin account, responsible for creating the above resources in each account in the organization.
+When run in Organizational mode, this module will be deployed via CloudFormation StackSets that should be created in the management account. They will create the above resources in each account in the organization, and automatically in any member accounts that are later added to the organization.
 
 This module will also deploy a Trusted Role Component and a Crypto Key Component in Sysdig Backend for onboarded Sysdig Cloud Account.
 
@@ -74,7 +74,6 @@ No modules.
 | <a name="auto_create_stackset_roles"></a> [auto\_create\_stackset\_roles](#input\_auto\_create\_stackset\_roles) | Whether to auto create the custom stackset roles to run SELF_MANAGED stackset | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
-| <a name="delegated_admin"></a> [delegated_admin](#input\_delegated\_admin) | Whether to create the resources using an delegated admin account | `bool` | `false` | no |
 | <a name="input_sysdig_secure_account_id"></a> [sysdig\_secure\_account\_id](#input\_sysdig\_secure\_account\_id) | ID of the Sysdig Cloud Account to enable Agentless Scanning for (incase of organization, ID of the Sysdig management account) | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/agentless-scanning/organizational.tf
+++ b/modules/agentless-scanning/organizational.tf
@@ -5,9 +5,6 @@
 # Non-global / Regional resources:
 # - a KMS Primary key is created, in each region of region list,
 # - an Alias by the same name for the respective key, in each region of region list.
-#
-# If a delegated admin account is used (determined via delegated_admin flag), service-managed stacksets will be created
-# acting as delegated_admin to deploy resources in all acocunts within AWS Organization.
 #-----------------------------------------------------------------------------------------------------------------------
 
 data "aws_organizations_organization" "org" {
@@ -43,8 +40,6 @@ resource "aws_cloudformation_stack_set" "scanning_role_stackset" {
   lifecycle {
     ignore_changes = [administration_role_arn]
   }
-
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
 
   template_body = <<TEMPLATE
 Resources:
@@ -143,8 +138,6 @@ resource "aws_cloudformation_stack_set_instance" "scanning_role_stackset_instanc
     # Roles are not regional and hence do not need regional parallelism
   }
 
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
-
   timeouts {
     create = var.timeout
     update = var.timeout
@@ -179,8 +172,6 @@ resource "aws_cloudformation_stack_set" "ou_resources_stackset" {
   lifecycle {
     ignore_changes = [administration_role_arn]
   }
-
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
 
   template_body = <<TEMPLATE
 Resources:
@@ -238,8 +229,6 @@ resource "aws_cloudformation_stack_set_instance" "ou_stackset_instance" {
     concurrency_mode             = "SOFT_FAILURE_TOLERANCE"
     region_concurrency_type      = "PARALLEL"
   }
-
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
 
   timeouts {
     create = var.timeout

--- a/modules/agentless-scanning/variables.tf
+++ b/modules/agentless-scanning/variables.tf
@@ -78,12 +78,6 @@ variable "failure_tolerance_percentage" {
   default     = 90
 }
 
-variable "delegated_admin" {
-  description = "Whether a delegated admin account will be used"
-  type        = bool
-  default     = false
-}
-
 variable "sysdig_secure_account_id" {
   type        = string
   description = "ID of the Sysdig Cloud Account to enable Agentless Scanning for (incase of organization, ID of the Sysdig management account)"

--- a/modules/config-posture/README.md
+++ b/modules/config-posture/README.md
@@ -51,7 +51,6 @@ No modules.
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the IAM Role that will be created. | `string` | `"sysdig-secure"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
-| <a name="delegated_admin"></a> [delegated_admin](#input\_delegated\_admin) | Whether to create the resources using an delegated admin account | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/config-posture/main.tf
+++ b/modules/config-posture/main.tf
@@ -18,7 +18,6 @@ data "sysdig_secure_tenant_external_id" "external_id" {}
 # Since this is not an Organizational deploy, create role/polices directly
 #----------------------------------------------------------
 resource "aws_iam_role" "cspm_role" {
-  count               = var.delegated_admin ? 0 : 1
   name                = local.config_posture_role_name
   tags                = var.tags
   assume_role_policy  = <<EOF

--- a/modules/config-posture/organizational.tf
+++ b/modules/config-posture/organizational.tf
@@ -35,8 +35,6 @@ resource "aws_cloudformation_stack_set" "stackset" {
     ignore_changes = [administration_role_arn]
   }
 
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
-
   template_body = <<TEMPLATE
 Resources:
   SysdigCSPMRole:
@@ -103,8 +101,6 @@ resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
     concurrency_mode             = "SOFT_FAILURE_TOLERANCE"
     # Roles are not regional and hence do not need regional parallelism
   }
-
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
 
   timeouts {
     create = var.timeout

--- a/modules/config-posture/variables.tf
+++ b/modules/config-posture/variables.tf
@@ -41,13 +41,6 @@ variable "failure_tolerance_percentage" {
   default     = 90
 }
 
-
-variable "delegated_admin" {
-  description = "Whether a delegated admin account will be used"
-  type        = bool
-  default     = false
-}
-
 variable "sysdig_secure_account_id" {
   type        = string
   description = "ID of the Sysdig Cloud Account to enable Config Posture for (incase of organization, ID of the Sysdig management account)"

--- a/modules/integrations/event-bridge/README.md
+++ b/modules/integrations/event-bridge/README.md
@@ -7,8 +7,7 @@ The following resources will be created in each instrumented account through Clo
 - An `EventBridge Target` that sends these events to an EventBridge Bus is Sysdig's AWS Account
 - An `IAM Role` and associated policies that gives the EventBridge Bus in the source account permission to call PutEvent on the EventBridge Bus in Sysdig's Account.
 
-When run in Organizational mode, this module will be deployed via CloudFormation StackSets that should be created in the management account. They will create the above resources in each account in the organization, and automatically in any member accounts that are later added to the organization. If a delegated admin account is used, only
-SERVICE_MANAGED stacksets will be created in the delegated admin account, responsible for creating the above resources in each account in the organization.
+When run in Organizational mode, this module will be deployed via CloudFormation StackSets that should be created in the management account. They will create the above resources in each account in the organization, and automatically in any member accounts that are later added to the organization.
 
 This module will also deploy an Event Bridge Component in Sysdig Backend for onboarded Sysdig Cloud Account.
 
@@ -72,7 +71,6 @@ No modules.
 | <a name="auto_create_stackset_roles"></a> [auto\_create\_stackset\_roles](#input\_auto\_create\_stackset\_roles) | Whether to auto create the custom stackset roles to run SELF_MANAGED stackset | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Tags to be attached to all Sysdig resources. | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
-| <a name="delegated_admin"></a> [delegated_admin](#input\_delegated\_admin) | Whether to create the resources using an delegated admin account | `bool` | `false` | no |
 | <a name="input_sysdig_secure_account_id"></a> [sysdig\_secure\_account\_id](#input\_sysdig\_secure\_account\_id) | ID of the Sysdig Cloud Account to enable Event Bridge integration for (incase of organization, ID of the Sysdig management account) | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/integrations/event-bridge/organizational.tf
+++ b/modules/integrations/event-bridge/organizational.tf
@@ -2,9 +2,6 @@
 # These resources set up an EventBridge Rule and Target to forward all CloudTrail events from the source account to
 # Sysdig in all accounts in an AWS Organization via service-managed CloudFormation StackSets.
 # For a single account installation, see main.tf.
-#
-# If a delegated admin account is used (determined via delegated_admin flag), service-managed stacksets will be created
-# acting as delegated_admin to deploy resources in all acocunts within AWS Organization.
 #-----------------------------------------------------------------------------------------------------------------------
 
 data "aws_organizations_organization" "org" {
@@ -37,8 +34,6 @@ resource "aws_cloudformation_stack_set" "eb-rule-stackset" {
     ignore_changes = [administration_role_arn]
   }
 
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
-
   template_body = templatefile("${path.module}/stackset_template_body.tpl", {
     name                 = local.eb_resource_name
     event_pattern        = var.event_pattern
@@ -68,8 +63,6 @@ resource "aws_cloudformation_stack_set" "eb-role-stackset" {
   lifecycle {
     ignore_changes = [administration_role_arn]
   }
-
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
 
   template_body = <<TEMPLATE
 Resources:
@@ -123,8 +116,6 @@ resource "aws_cloudformation_stack_set_instance" "eb_rule_stackset_instance" {
     region_concurrency_type      = "PARALLEL"
   }
 
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
-
   timeouts {
     create = var.timeout
     update = var.timeout
@@ -146,8 +137,6 @@ resource "aws_cloudformation_stack_set_instance" "eb_role_stackset_instance" {
     concurrency_mode             = "SOFT_FAILURE_TOLERANCE"
     # Roles are not regional and hence do not need regional parallelism
   }
-
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
 
   timeouts {
     create = var.timeout

--- a/modules/integrations/event-bridge/variables.tf
+++ b/modules/integrations/event-bridge/variables.tf
@@ -79,12 +79,6 @@ variable "failure_tolerance_percentage" {
   default     = 90
 }
 
-variable "delegated_admin" {
-  description = "Whether a delegated admin account will be used"
-  type        = bool
-  default     = false
-}
-
 variable "auto_create_stackset_roles" {
   description = "Whether to auto create the custom stackset roles to run SELF_MANAGED stackset. Default is true"
   type        = bool

--- a/modules/onboarding/README.md
+++ b/modules/onboarding/README.md
@@ -51,7 +51,6 @@ No modules.
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the IAM Role that will be created. | `string` | `"sysdig-secure"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
-| <a name="delegated_admin"></a> [delegated_admin](#input\_delegated\_admin) | Whether to create the resources using an delegated admin account | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/onboarding/main.tf
+++ b/modules/onboarding/main.tf
@@ -21,7 +21,6 @@ data "sysdig_secure_tenant_external_id" "external_id" {}
 # Since this is not an Organizational deploy, create role/polices directly
 #----------------------------------------------------------
 resource "aws_iam_role" "onboarding_role" {
-  count              = var.delegated_admin ? 0 : 1
   name               = local.onboarding_role_name
   tags               = var.tags
   assume_role_policy = <<EOF

--- a/modules/onboarding/organizational.tf
+++ b/modules/onboarding/organizational.tf
@@ -35,8 +35,6 @@ resource "aws_cloudformation_stack_set" "stackset" {
     ignore_changes = [administration_role_arn]
   }
 
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
-
   template_body = <<TEMPLATE
 Resources:
   SysdigOnboardingRole:
@@ -72,8 +70,6 @@ resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
     concurrency_mode             = "SOFT_FAILURE_TOLERANCE"
     # Roles are not regional and hence do not need regional parallelism
   }
-
-  call_as = var.delegated_admin ? "DELEGATED_ADMIN" : "SELF"
 
   timeouts {
     create = var.timeout

--- a/modules/onboarding/variables.tf
+++ b/modules/onboarding/variables.tf
@@ -40,10 +40,3 @@ variable "failure_tolerance_percentage" {
   description = "The percentage of accounts, per Region, for which stack operations can fail before AWS CloudFormation stops the operation in that Region"
   default     = 90
 }
-
-
-variable "delegated_admin" {
-  description = "Whether a delegated admin account will be used"
-  type        = bool
-  default     = false
-}


### PR DESCRIPTION
Fix summary:
-------------
Fixing the partial support for delegated_admin in all modules, since this support does not fully onboard an org via delegated admin account today.

Note: the full, complete and well tested support for delegated admin will be added later separately.