### PR TITLE
enhance(modular): handle deprecated resources in modules

### DIFF
--- a/modules/agentless-scanning/outputs.tf
+++ b/modules/agentless-scanning/outputs.tf
@@ -1,11 +1,11 @@
 output "scanning_role_component_id" {
   value       = "${sysdig_secure_cloud_auth_account_component.aws_scanning_role.type}/${sysdig_secure_cloud_auth_account_component.aws_scanning_role.instance}"
   description = "Component identifier of scanning role created in Sysdig Backend for Agentless Scanning"
-  depends_on = [ sysdig_secure_cloud_auth_account_component.aws_scanning_role ]
+  depends_on  = [sysdig_secure_cloud_auth_account_component.aws_scanning_role]
 }
 
 output "crypto_key_component_id" {
   value       = "${sysdig_secure_cloud_auth_account_component.aws_crypto_key.type}/${sysdig_secure_cloud_auth_account_component.aws_crypto_key.instance}"
   description = "Component identifier of KMS crypto key created in Sysdig Backend for Agentless Scanning"
-  depends_on = [ sysdig_secure_cloud_auth_account_component.aws_crypto_key ]
+  depends_on  = [sysdig_secure_cloud_auth_account_component.aws_crypto_key]
 }

--- a/modules/agentless-scanning/variables.tf
+++ b/modules/agentless-scanning/variables.tf
@@ -56,8 +56,8 @@ variable "stackset_admin_role_arn" {
 
 variable "stackset_execution_role_name" {
   description = "(Optional) stackset execution role name to run SELF_MANAGED stackset"
-    type        = string
-    default     = ""
+  type        = string
+  default     = ""
 }
 
 variable "timeout" {

--- a/modules/agentless-scanning/versions.tf
+++ b/modules/agentless-scanning/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = ">= 5.60.0"
     }
     sysdig = {
-      source  = "sysdiglabs/sysdig"
+      source = "sysdiglabs/sysdig"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/config-posture/outputs.tf
+++ b/modules/config-posture/outputs.tf
@@ -1,5 +1,5 @@
 output "config_posture_component_id" {
   value       = "${sysdig_secure_cloud_auth_account_component.config_posture_role.type}/${sysdig_secure_cloud_auth_account_component.config_posture_role.instance}"
   description = "Component identifier of trusted identity created in Sysdig Backend for Config Posture"
-  depends_on = [ sysdig_secure_cloud_auth_account_component.config_posture_role ]
+  depends_on  = [sysdig_secure_cloud_auth_account_component.config_posture_role]
 }

--- a/modules/config-posture/versions.tf
+++ b/modules/config-posture/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = ">= 5.60.0"
     }
     sysdig = {
-      source  = "sysdiglabs/sysdig"
+      source = "sysdiglabs/sysdig"
     }
   }
 }

--- a/modules/integrations/event-bridge/outputs.tf
+++ b/modules/integrations/event-bridge/outputs.tf
@@ -1,5 +1,5 @@
 output "event_bridge_component_id" {
   value       = "${sysdig_secure_cloud_auth_account_component.aws_event_bridge.type}/${sysdig_secure_cloud_auth_account_component.aws_event_bridge.instance}"
   description = "Component identifier of Event Bridge integration created in Sysdig Backend for Log Ingestion"
-  depends_on = [ sysdig_secure_cloud_auth_account_component.aws_event_bridge ]
+  depends_on  = [sysdig_secure_cloud_auth_account_component.aws_event_bridge]
 }

--- a/modules/integrations/event-bridge/variables.tf
+++ b/modules/integrations/event-bridge/variables.tf
@@ -93,8 +93,8 @@ variable "stackset_admin_role_arn" {
 
 variable "stackset_execution_role_name" {
   description = "(Optional) stackset execution role name to run SELF_MANAGED stackset"
-    type        = string
-    default     = ""
+  type        = string
+  default     = ""
 }
 
 variable "sysdig_secure_account_id" {

--- a/modules/integrations/event-bridge/versions.tf
+++ b/modules/integrations/event-bridge/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = ">= 5.60.0"
     }
     sysdig = {
-      source  = "sysdiglabs/sysdig"
+      source = "sysdiglabs/sysdig"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/onboarding/main.tf
+++ b/modules/onboarding/main.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 data "sysdig_secure_trusted_cloud_identity" "trusted_identity" {
-	cloud_provider = "aws"
+  cloud_provider = "aws"
 }
 
 data "sysdig_secure_tenant_external_id" "external_id" {}
@@ -49,7 +49,7 @@ EOF
   ])
 
   lifecycle {
-    ignore_changes = [ tags ]
+    ignore_changes = [tags]
   }
 }
 

--- a/modules/onboarding/organizational.tf
+++ b/modules/onboarding/organizational.tf
@@ -7,7 +7,7 @@ data "aws_organizations_organization" "org" {
 }
 
 locals {
-  org_units_to_deploy  = var.is_organizational && length(var.organizational_unit_ids) == 0 ? [for root in data.aws_organizations_organization.org[0].roots : root.id] : var.organizational_unit_ids
+  org_units_to_deploy = var.is_organizational && length(var.organizational_unit_ids) == 0 ? [for root in data.aws_organizations_organization.org[0].roots : root.id] : var.organizational_unit_ids
 }
 
 #----------------------------------------------------------
@@ -79,7 +79,7 @@ resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
 }
 
 resource "sysdig_secure_organization" "aws_organization" {
-  count = var.is_organizational ? 1 : 0
-  management_account_id = sysdig_secure_cloud_auth_account.cloud_auth_account.id
-  organizational_unit_ids  = var.organizational_unit_ids
+  count                   = var.is_organizational ? 1 : 0
+  management_account_id   = sysdig_secure_cloud_auth_account.cloud_auth_account.id
+  organizational_unit_ids = var.organizational_unit_ids
 }

--- a/modules/onboarding/versions.tf
+++ b/modules/onboarding/versions.tf
@@ -10,7 +10,7 @@ terraform {
       version = ">= 3.1"
     }
     sysdig = {
-      source  = "sysdiglabs/sysdig"
+      source = "sysdiglabs/sysdig"
     }
   }
 }


### PR DESCRIPTION
xref: https://sysdig.atlassian.net/browse/SSPROD-47604

This PR has some fixes to avoid warnings around deprecated resources in TF to avoid `warnings` for the user.

Leverages the use of `aws_iam_role_policy` instead of `inline_policy` attributes, this was tested for single and organization for `Foundational` + `CDR/CIEM` + `VM` and run the validation manually too.