### PR TITLE
fix(modular): make account alias optional in onboarding module

### DIFF
--- a/modules/onboarding/main.tf
+++ b/modules/onboarding/main.tf
@@ -54,13 +54,12 @@ EOF
 }
 
 data "aws_caller_identity" "current" {}
-data "aws_iam_account_alias" "current" {}
 
 resource "sysdig_secure_cloud_auth_account" "cloud_auth_account" {
   enabled        = true
   provider_id    = data.aws_caller_identity.current.account_id
   provider_type  = "PROVIDER_AWS"
-  provider_alias = data.aws_iam_account_alias.current.account_alias
+  provider_alias = var.account_alias
 
   component {
     type     = "COMPONENT_TRUSTED_ROLE"

--- a/modules/onboarding/variables.tf
+++ b/modules/onboarding/variables.tf
@@ -40,3 +40,10 @@ variable "failure_tolerance_percentage" {
   description = "The percentage of accounts, per Region, for which stack operations can fail before AWS CloudFormation stops the operation in that Region"
   default     = 90
 }
+
+variable "account_alias" {
+  type        = string
+  description = "Account Alias"
+  default     = ""
+}
+


### PR DESCRIPTION
xref: https://sysdig.atlassian.net/browse/SSPROD-47600

This PR makes the `aws account alias` as optional since the `aws_iam_account_alias` datasource is broken as mentioned within the ticket above.

Before doing this, some steps were tried however there's no solution yet:
1. Tried to create `null_resource` without having the user install additional tooling - Not possible.
2. Open a PR on the AWS TF provider side to fix the issue - Opened the PR currently waiting on a review

Finally, while we wait on the provider to be fixed or do it on the BE, we want to avoid the error for accounts without alias by making it an optional variable.