### PR TITLE
enhance(modular): handle deprecated resources and fix warnings

### DIFF
--- a/modules/agentless-scanning/main.tf
+++ b/modules/agentless-scanning/main.tf
@@ -70,7 +70,7 @@ resource "aws_iam_role" "scanning_stackset_admin_role" {
   name = "AWSCloudFormationStackSetAdministrationRoleForScanning"
   tags = var.tags
 
-  assume_role_policy  = <<EOF
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -84,7 +84,12 @@ resource "aws_iam_role" "scanning_stackset_admin_role" {
   ]
 }
 EOF
-  managed_policy_arns = ["arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"]
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "scanning_stackset_admin_role_managed_policy" {
+  count       = !var.auto_create_stackset_roles ? 0 : 1
+  role_name   = aws_iam_role.scanning_stackset_admin_role[0].id
+  policy_arns = ["arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"]
 }
 
 resource "aws_iam_role_policy" "scanning_stackset_admin_role_policy" {
@@ -135,9 +140,12 @@ resource "aws_iam_role" "scanning_stackset_execution_role" {
   ]
 }
 EOF
-  managed_policy_arns = [
-    "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
-  ]
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "scanning_stackset_execution_role_managed_policy" {
+  count       = !var.auto_create_stackset_roles ? 0 : 1
+  role_name   = aws_iam_role.scanning_stackset_execution_role[0].id
+  policy_arns = ["arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"]
 }
 
 resource "aws_iam_role_policy" "scanning_stackset_execution_role_policy" {

--- a/modules/config-posture/main.tf
+++ b/modules/config-posture/main.tf
@@ -18,9 +18,9 @@ data "sysdig_secure_tenant_external_id" "external_id" {}
 # Since this is not an Organizational deploy, create role/polices directly
 #----------------------------------------------------------
 resource "aws_iam_role" "cspm_role" {
-  name                = local.config_posture_role_name
-  tags                = var.tags
-  assume_role_policy  = <<EOF
+  name               = local.config_posture_role_name
+  tags               = var.tags
+  assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -40,7 +40,13 @@ resource "aws_iam_role" "cspm_role" {
     ]
 }
 EOF
-  managed_policy_arns = ["arn:aws:iam::aws:policy/SecurityAudit"]
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "cspm_role_managed_policy" {
+  role_name = aws_iam_role.cspm_role.id
+  policy_arns = [
+    "arn:aws:iam::aws:policy/SecurityAudit"
+  ]
 }
 
 resource "aws_iam_role_policy" "cspm_role_policy" {

--- a/modules/integrations/event-bridge/main.tf
+++ b/modules/integrations/event-bridge/main.tf
@@ -59,7 +59,7 @@ resource "aws_iam_role" "event_bus_stackset_admin_role" {
   name = "AWSCloudFormationStackSetAdministrationRoleForEB"
   tags = var.tags
 
-  assume_role_policy  = <<EOF
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -73,7 +73,14 @@ resource "aws_iam_role" "event_bus_stackset_admin_role" {
   ]
 }
 EOF
-  managed_policy_arns = ["arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"]
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "event_bus_stackset_admin_role_managed_policy" {
+  count     = !var.auto_create_stackset_roles ? 0 : 1
+  role_name = aws_iam_role.event_bus_stackset_admin_role[0].id
+  policy_arns = [
+    "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
+  ]
 }
 
 #-----------------------------------------------------------------------------------------------------------------------------------------
@@ -105,7 +112,12 @@ resource "aws_iam_role" "event_bus_stackset_execution_role" {
   ]
 }
 EOF
-  managed_policy_arns = [
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "event_bus_stackset_execution_role_managed_policy" {
+  count     = !var.auto_create_stackset_roles ? 0 : 1
+  role_name = aws_iam_role.event_bus_stackset_execution_role[0].id
+  policy_arns = [
     "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess",
     "arn:aws:iam::aws:policy/AmazonEventBridgeFullAccess"
   ]

--- a/modules/onboarding/main.tf
+++ b/modules/onboarding/main.tf
@@ -43,23 +43,28 @@ resource "aws_iam_role" "onboarding_role" {
     ]
 }
 EOF
-  managed_policy_arns = compact([
-    "arn:aws:iam::aws:policy/AWSAccountManagementReadOnlyAccess",
-    var.is_organizational ? "arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess" : ""
-  ])
 
   lifecycle {
     ignore_changes = [tags]
   }
 }
 
+resource "aws_iam_role_policy_attachments_exclusive" "onboarding_role_managed_policy" {
+  role_name = aws_iam_role.onboarding_role.id
+  policy_arns = compact([
+    "arn:aws:iam::aws:policy/AWSAccountManagementReadOnlyAccess",
+    var.is_organizational ? "arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess" : ""
+  ])
+}
+
 data "aws_caller_identity" "current" {}
 
 resource "sysdig_secure_cloud_auth_account" "cloud_auth_account" {
-  enabled        = true
-  provider_id    = data.aws_caller_identity.current.account_id
-  provider_type  = "PROVIDER_AWS"
-  provider_alias = var.account_alias
+  enabled              = true
+  provider_id          = data.aws_caller_identity.current.account_id
+  provider_type        = "PROVIDER_AWS"
+  provider_alias       = var.account_alias
+  regulatory_framework = "REGULATORY_FRAMEWORK_UNSPECIFIED"
 
   component {
     type     = "COMPONENT_TRUSTED_ROLE"


### PR DESCRIPTION
xref: https://sysdig.atlassian.net/browse/SSPROD-48172

This PR handles deprecated resources and move from `managed_policy_arns` within an `aws_iam_role` to `aws_iam_role_policy_attachments_exclusive` as recommended within the warning output mentioned in the ticket.