### PR TITLE
feat(modules): Support for Govcloud account/org for fedramp

### DIFF
--- a/modules/config-posture/README.md
+++ b/modules/config-posture/README.md
@@ -56,7 +56,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
 | <a name="input_sysdig_secure_account_id"></a> [sysdig\_secure\_account\_id](#input\_sysdig\_secure\_account\_id) | (Required) The GUID of the management project or single project per sysdig representation | `string` | n/a | yes |
-| <a name="input_is_gov_cloud"></a> [is\_gov\_cloud](#input\_is\_gov\_cloud) | true/false whether secure-for-cloud should be deployed in a govcloud account/org or not | `bool` | `false` | no |
+| <a name="input_is_gov_cloud_onboarding"></a> [is\_gov\_cloud\_onboarding](#input\_is\_gov\_cloud\_onboarding) | true/false whether secure-for-cloud should be deployed in a govcloud account/org or not | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/config-posture/README.md
+++ b/modules/config-posture/README.md
@@ -10,6 +10,8 @@ The following resources will be created in each instrumented account:
 
 If instrumenting an AWS Organization, an `aws_cloudformation_stack_set` will be created in the Management Account.
 
+If instrumenting an AWS Gov account/organization, IAM policies and resources will be created in `aws-us-gov` region.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -32,29 +34,35 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [random_id.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_iam_role.cspm_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachments_exclusive.cspm_role_managed_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [aws_iam_role_policy.cspm_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [sysdig_secure_cloud_auth_account_component.config_posture_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_auth_account_component) | resource |
 | [aws_cloudformation_stack_set.stackset](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
 | [aws_cloudformation_stack_set_instance.stackset_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
-| [aws_iam_role.cspm_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_policy_document.custom_resources_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [sysdig_secure_trusted_cloud_identity.trusted_identity](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_trusted_cloud_identity) | data source |
+| [sysdig_secure_tenant_external_id.external_id](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_tenant_external_id) | data source |
 | [aws_organizations_organization.org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_external_id"></a> [external\_id](#input\_external\_id) | Random string generated unique to a customer | `string` | n/a | yes |
-| <a name="input_trusted_identity"></a> [trusted\_identity](#input\_trusted\_identity) | The name of sysdig trusted identity | `string` | n/a | yes |
 | <a name="input_failure_tolerance_percentage"></a> [failure\_tolerance\_percentage](#input\_failure\_tolerance\_percentage) | The percentage of accounts, per Region, for which stack operations can fail before AWS CloudFormation stops the operation in that Region | `number` | `90` | no |
 | <a name="input_is_organizational"></a> [is\_organizational](#input\_is\_organizational) | true/false whether secure-for-cloud should be deployed in an organizational setup (all accounts of org) or not (only on default aws provider account) | `bool` | `false` | no |
 | <a name="input_org_units"></a> [org\_units](#input\_org\_units) | Org unit id to install cspm | `set(string)` | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | Default region for resource creation in organization mode | `string` | `""` | no |
-| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the IAM Role that will be created. | `string` | `"sysdig-secure"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
+| <a name="input_sysdig_secure_account_id"></a> [sysdig\_secure\_account\_id](#input\_sysdig\_secure\_account\_id) | (Required) The GUID of the management project or single project per sysdig representation | `string` | n/a | yes |
+| <a name="input_is_gov_cloud"></a> [is\_gov\_cloud](#input\_is\_gov\_cloud) | true/false whether secure-for-cloud should be deployed in a govcloud account/org or not | `bool` | `false` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_config_posture_component_id"></a> [config\_posture\_component\_id](#output\_config\_posture\_component\_id) | The component id of the config posture trusted identity |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/modules/config-posture/README.md
+++ b/modules/config-posture/README.md
@@ -19,6 +19,7 @@ If instrumenting an AWS Gov account/organization, IAM policies and resources wil
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.60.0 |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | ~>1.39 |
 
 ## Providers
 

--- a/modules/config-posture/main.tf
+++ b/modules/config-posture/main.tf
@@ -19,8 +19,8 @@ resource "random_id" "suffix" {
 
 locals {
   config_posture_role_name = "sysdig-secure-posture-${random_id.suffix.hex}"
-  trusted_identity         = var.is_gov_cloud ? data.sysdig_secure_trusted_cloud_identity.trusted_identity.gov_identity : data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity
-  arn_prefix               = var.is_gov_cloud ? "arn:aws-us-gov" : "arn:aws"
+  trusted_identity         = var.is_gov_cloud_onboarding ? data.sysdig_secure_trusted_cloud_identity.trusted_identity.gov_identity : data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity
+  arn_prefix               = var.is_gov_cloud_onboarding ? "arn:aws-us-gov" : "arn:aws"
 }
 
 #----------------------------------------------------------

--- a/modules/config-posture/main.tf
+++ b/modules/config-posture/main.tf
@@ -1,18 +1,27 @@
-// generate a random suffix for the config-posture role name
-
-resource "random_id" "suffix" {
-  byte_length = 3
-}
-
-locals {
-  config_posture_role_name = "sysdig-secure-posture-${random_id.suffix.hex}"
-}
+#-----------------------------------------------------------------------------------------
+# Fetch the data sources
+#-----------------------------------------------------------------------------------------
 
 data "sysdig_secure_trusted_cloud_identity" "trusted_identity" {
   cloud_provider = "aws"
 }
 
 data "sysdig_secure_tenant_external_id" "external_id" {}
+
+#----------------------------------------------------------
+# Fetch & compute required data
+#----------------------------------------------------------
+
+// generate a random suffix for the config-posture role name
+resource "random_id" "suffix" {
+  byte_length = 3
+}
+
+locals {
+  config_posture_role_name = "sysdig-secure-posture-${random_id.suffix.hex}"
+  trusted_identity         = var.is_gov_cloud ? data.sysdig_secure_trusted_cloud_identity.trusted_identity.gov_identity : data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity
+  arn_prefix               = var.is_gov_cloud ? "arn:aws-us-gov" : "arn:aws"
+}
 
 #----------------------------------------------------------
 # Since this is not an Organizational deploy, create role/polices directly
@@ -28,7 +37,7 @@ resource "aws_iam_role" "cspm_role" {
             "Sid": "",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "${data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity}"
+                "AWS": "${local.trusted_identity}"
             },
             "Action": "sts:AssumeRole",
             "Condition": {
@@ -45,7 +54,7 @@ EOF
 resource "aws_iam_role_policy_attachments_exclusive" "cspm_role_managed_policy" {
   role_name = aws_iam_role.cspm_role.id
   policy_arns = [
-    "arn:aws:iam::aws:policy/SecurityAudit"
+    "${local.arn_prefix}:iam::aws:policy/SecurityAudit"
   ]
 }
 
@@ -70,8 +79,8 @@ resource "aws_iam_role_policy" "cspm_role_policy" {
         ]
         Effect = "Allow"
         Resource = [
-          "arn:aws:waf-regional:*:*:rule/*",
-          "arn:aws:waf-regional:*:*:rulegroup/*"
+          "${local.arn_prefix}:waf-regional:*:*:rule/*",
+          "${local.arn_prefix}:waf-regional:*:*:rulegroup/*"
         ]
       },
       {

--- a/modules/config-posture/organizational.tf
+++ b/modules/config-posture/organizational.tf
@@ -45,13 +45,13 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: [ ${data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity} ]
+              AWS: [ ${local.trusted_identity} ]
             Action: [ 'sts:AssumeRole' ]
             Condition:
               StringEquals:
                 sts:ExternalId: ${data.sysdig_secure_tenant_external_id.external_id.external_id}
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/SecurityAudit"
+        - "${local.arn_prefix}:iam::aws:policy/SecurityAudit"
       Policies:
         - PolicyName: ${local.config_posture_role_name}
           PolicyDocument:
@@ -67,8 +67,8 @@ Resources:
                   - "waf-regional:ListRules"
                   - "waf-regional:ListRuleGroups"
                 Resource:
-                  - "arn:aws:waf-regional:*:*:rule/*"
-                  - "arn:aws:waf-regional:*:*:rulegroup/*"
+                  - "${local.arn_prefix}:waf-regional:*:*:rule/*"
+                  - "${local.arn_prefix}:waf-regional:*:*:rulegroup/*"
               - Sid: "ListJobsOnConsole"
                 Effect: "Allow"
                 Action: "macie2:ListClassificationJobs"

--- a/modules/config-posture/variables.tf
+++ b/modules/config-posture/variables.tf
@@ -45,3 +45,9 @@ variable "sysdig_secure_account_id" {
   type        = string
   description = "ID of the Sysdig Cloud Account to enable Config Posture for (incase of organization, ID of the Sysdig management account)"
 }
+
+variable "is_gov_cloud" {
+  type        = bool
+  default     = false
+  description = "true/false whether secure-for-cloud should be deployed in a govcloud account/org or not"
+}

--- a/modules/config-posture/variables.tf
+++ b/modules/config-posture/variables.tf
@@ -46,7 +46,7 @@ variable "sysdig_secure_account_id" {
   description = "ID of the Sysdig Cloud Account to enable Config Posture for (incase of organization, ID of the Sysdig management account)"
 }
 
-variable "is_gov_cloud" {
+variable "is_gov_cloud_onboarding" {
   type        = bool
   default     = false
   description = "true/false whether secure-for-cloud should be deployed in a govcloud account/org or not"

--- a/modules/config-posture/versions.tf
+++ b/modules/config-posture/versions.tf
@@ -6,8 +6,8 @@ terraform {
       version = ">= 5.60.0"
     }
     sysdig = {
-      source  = "local/sysdiglabs/sysdig" // TODO: remove after test
-      version = "~> 1.0.0"
+      source  = "sysdiglabs/sysdig"
+      version = "~> 1.39"
     }
   }
 }

--- a/modules/config-posture/versions.tf
+++ b/modules/config-posture/versions.tf
@@ -6,7 +6,8 @@ terraform {
       version = ">= 5.60.0"
     }
     sysdig = {
-      source = "sysdiglabs/sysdig"
+      source  = "local/sysdiglabs/sysdig" // TODO: remove after test
+      version = "~> 1.0.0"
     }
   }
 }

--- a/modules/integrations/event-bridge/README.md
+++ b/modules/integrations/event-bridge/README.md
@@ -74,7 +74,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Tags to be attached to all Sysdig resources. | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
 | <a name="input_sysdig_secure_account_id"></a> [sysdig\_secure\_account\_id](#input\_sysdig\_secure\_account\_id) | ID of the Sysdig Cloud Account to enable Event Bridge integration for (incase of organization, ID of the Sysdig management account) | `string` | n/a | yes |
-| <a name="input_is_gov_cloud"></a> [is\_gov\_cloud](#input\_is\_gov\_cloud) | true/false whether Event Bridge should be deployed in a govcloud account/org or not | `bool` | `false` | no |
+| <a name="input_is_gov_cloud_onboarding"></a> [is\_gov\_cloud\_onboarding](#input\_is\_gov\_cloud\_onboarding) | true/false whether Event Bridge should be deployed in a govcloud account/org or not | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/integrations/event-bridge/README.md
+++ b/modules/integrations/event-bridge/README.md
@@ -11,6 +11,8 @@ When run in Organizational mode, this module will be deployed via CloudFormation
 
 This module will also deploy an Event Bridge Component in Sysdig Backend for onboarded Sysdig Cloud Account.
 
+If instrumenting an AWS Gov account/organization, IAM policies and event bridge resources will be created in `aws-us-gov` region.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -72,6 +74,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Tags to be attached to all Sysdig resources. | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
 | <a name="input_sysdig_secure_account_id"></a> [sysdig\_secure\_account\_id](#input\_sysdig\_secure\_account\_id) | ID of the Sysdig Cloud Account to enable Event Bridge integration for (incase of organization, ID of the Sysdig management account) | `string` | n/a | yes |
+| <a name="input_is_gov_cloud"></a> [is\_gov\_cloud](#input\_is\_gov\_cloud) | true/false whether Event Bridge should be deployed in a govcloud account/org or not | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/integrations/event-bridge/README.md
+++ b/modules/integrations/event-bridge/README.md
@@ -20,7 +20,7 @@ If instrumenting an AWS Gov account/organization, IAM policies and event bridge 
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.60.0 |
-| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | ~>1.39 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1 |
 
 

--- a/modules/integrations/event-bridge/main.tf
+++ b/modules/integrations/event-bridge/main.tf
@@ -27,9 +27,9 @@ data "sysdig_secure_tenant_external_id" "external_id" {}
 #-----------------------------------------------------------------------------------------
 locals {
   region_set           = toset(var.regions)
-  trusted_identity     = var.is_gov_cloud ? data.sysdig_secure_trusted_cloud_identity.trusted_identity.gov_identity : data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity
-  target_event_bus_arn = var.is_gov_cloud ? data.sysdig_secure_cloud_ingestion_assets.assets.aws.eventBusARNGov : data.sysdig_secure_cloud_ingestion_assets.assets.aws.eventBusARN
-  arn_prefix           = var.is_gov_cloud ? "arn:aws-us-gov" : "arn:aws"
+  trusted_identity     = var.is_gov_cloud_onboarding ? data.sysdig_secure_trusted_cloud_identity.trusted_identity.gov_identity : data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity
+  target_event_bus_arn = var.is_gov_cloud_onboarding ? data.sysdig_secure_cloud_ingestion_assets.assets.aws.eventBusARNGov : data.sysdig_secure_cloud_ingestion_assets.assets.aws.eventBusARN
+  arn_prefix           = var.is_gov_cloud_onboarding ? "arn:aws-us-gov" : "arn:aws"
 }
 
 #-----------------------------------------------------------------------------------------

--- a/modules/integrations/event-bridge/main.tf
+++ b/modules/integrations/event-bridge/main.tf
@@ -26,7 +26,10 @@ data "sysdig_secure_tenant_external_id" "external_id" {}
 # These locals indicate the region list passed.
 #-----------------------------------------------------------------------------------------
 locals {
-  region_set = toset(var.regions)
+  region_set           = toset(var.regions)
+  trusted_identity     = var.is_gov_cloud ? data.sysdig_secure_trusted_cloud_identity.trusted_identity.gov_identity : data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity
+  target_event_bus_arn = var.is_gov_cloud ? data.sysdig_secure_cloud_ingestion_assets.assets.aws.eventBusARNGov : data.sysdig_secure_cloud_ingestion_assets.assets.aws.eventBusARN
+  arn_prefix           = var.is_gov_cloud ? "arn:aws-us-gov" : "arn:aws"
 }
 
 #-----------------------------------------------------------------------------------------
@@ -79,7 +82,7 @@ resource "aws_iam_role_policy_attachments_exclusive" "event_bus_stackset_admin_r
   count     = !var.auto_create_stackset_roles ? 0 : 1
   role_name = aws_iam_role.event_bus_stackset_admin_role[0].id
   policy_arns = [
-    "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
+    "${local.arn_prefix}:iam::aws:policy/AWSCloudFormationFullAccess"
   ]
 }
 
@@ -104,7 +107,7 @@ resource "aws_iam_role" "event_bus_stackset_execution_role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${aws_iam_role.event_bus_stackset_admin_role[0].name}"
+        "AWS": "${local.arn_prefix}:iam::${data.aws_caller_identity.current.account_id}:role/${aws_iam_role.event_bus_stackset_admin_role[0].name}"
       },
       "Effect": "Allow",
       "Condition": {}
@@ -118,8 +121,8 @@ resource "aws_iam_role_policy_attachments_exclusive" "event_bus_stackset_executi
   count     = !var.auto_create_stackset_roles ? 0 : 1
   role_name = aws_iam_role.event_bus_stackset_execution_role[0].id
   policy_arns = [
-    "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess",
-    "arn:aws:iam::aws:policy/AmazonEventBridgeFullAccess"
+    "${local.arn_prefix}:iam::aws:policy/AWSCloudFormationFullAccess",
+    "${local.arn_prefix}:iam::aws:policy/AmazonEventBridgeFullAccess"
   ]
 }
 
@@ -149,7 +152,7 @@ resource "aws_iam_role" "event_bus_invoke_remote_event_bus" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "AWS": "${data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity}"
+        "AWS": "${local.trusted_identity}"
       },
       "Effect": "Allow",
       "Condition": {
@@ -163,7 +166,6 @@ resource "aws_iam_role" "event_bus_invoke_remote_event_bus" {
 EOF
 }
 
-
 resource "aws_iam_role_policy" "event_bus_invoke_remote_event_bus_policy" {
   name = local.eb_resource_name
   role = aws_iam_role.event_bus_invoke_remote_event_bus.id
@@ -176,7 +178,7 @@ resource "aws_iam_role_policy" "event_bus_invoke_remote_event_bus_policy" {
         ]
         Effect = "Allow"
         Resource = [
-          data.sysdig_secure_cloud_ingestion_assets.assets.aws.eventBusARN,
+          "${local.target_event_bus_arn}",
         ]
       },
       {
@@ -187,7 +189,7 @@ resource "aws_iam_role_policy" "event_bus_invoke_remote_event_bus_policy" {
         ]
         Effect = "Allow"
         Resource = [
-          "arn:aws:events:*:*:rule/${local.eb_resource_name}",
+          "${local.arn_prefix}:events:*:*:rule/${local.eb_resource_name}",
         ]
       },
     ]
@@ -226,7 +228,8 @@ resource "aws_cloudformation_stack_set" "primary-acc-stackset" {
     name                 = local.eb_resource_name
     event_pattern        = var.event_pattern
     rule_state           = var.rule_state
-    target_event_bus_arn = data.sysdig_secure_cloud_ingestion_assets.assets.aws.eventBusARN
+    arn_prefix           = local.arn_prefix
+    target_event_bus_arn = local.target_event_bus_arn
   })
 
   depends_on = [

--- a/modules/integrations/event-bridge/organizational.tf
+++ b/modules/integrations/event-bridge/organizational.tf
@@ -38,7 +38,8 @@ resource "aws_cloudformation_stack_set" "eb-rule-stackset" {
     name                 = local.eb_resource_name
     event_pattern        = var.event_pattern
     rule_state           = var.rule_state
-    target_event_bus_arn = data.sysdig_secure_cloud_ingestion_assets.assets.aws.eventBusARN
+    arn_prefix           = local.arn_prefix
+    target_event_bus_arn = local.target_event_bus_arn
   })
 }
 
@@ -79,7 +80,7 @@ Resources:
               Action: 'sts:AssumeRole'
             - Effect: "Allow"
               Principal:
-                AWS: "${data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity}"
+                AWS: "${local.trusted_identity}"
               Action: "sts:AssumeRole"
               Condition:
                 StringEquals:
@@ -91,12 +92,12 @@ Resources:
               Statement:
                 - Effect: Allow
                   Action: 'events:PutEvents'
-                  Resource: ${data.sysdig_secure_cloud_ingestion_assets.assets.aws.eventBusARN}
+                  Resource: "${local.target_event_bus_arn}"
                 - Effect: Allow
                   Action:
                     - "events:DescribeRule"
                     - "events:ListTargetsByRule"
-                  Resource: "arn:aws:events:*:*:rule/${local.eb_resource_name}"
+                  Resource: "${local.arn_prefix}:events:*:*:rule/${local.eb_resource_name}"
 TEMPLATE
 }
 

--- a/modules/integrations/event-bridge/stackset_template_body.tpl
+++ b/modules/integrations/event-bridge/stackset_template_body.tpl
@@ -9,4 +9,4 @@ Resources:
       Targets:
         - Id: ${name}
           Arn: ${target_event_bus_arn}
-          RoleArn: !Sub "arn:aws:iam::$${AWS::AccountId}:role/${name}"
+          RoleArn: !Sub "${arn_prefix}:iam::$${AWS::AccountId}:role/${name}"

--- a/modules/integrations/event-bridge/variables.tf
+++ b/modules/integrations/event-bridge/variables.tf
@@ -102,7 +102,7 @@ variable "sysdig_secure_account_id" {
   description = "ID of the Sysdig Cloud Account to enable Event Bridge integration for (incase of organization, ID of the Sysdig management account)"
 }
 
-variable "is_gov_cloud" {
+variable "is_gov_cloud_onboarding" {
   type        = bool
   default     = false
   description = "true/false whether EventBridge should be deployed in a govcloud account/org or not"

--- a/modules/integrations/event-bridge/variables.tf
+++ b/modules/integrations/event-bridge/variables.tf
@@ -101,3 +101,9 @@ variable "sysdig_secure_account_id" {
   type        = string
   description = "ID of the Sysdig Cloud Account to enable Event Bridge integration for (incase of organization, ID of the Sysdig management account)"
 }
+
+variable "is_gov_cloud" {
+  type        = bool
+  default     = false
+  description = "true/false whether EventBridge should be deployed in a govcloud account/org or not"
+}

--- a/modules/integrations/event-bridge/versions.tf
+++ b/modules/integrations/event-bridge/versions.tf
@@ -6,8 +6,8 @@ terraform {
       version = ">= 5.60.0"
     }
     sysdig = {
-      source  = "local/sysdiglabs/sysdig" // TODO: remove after test
-      version = "~> 1.0.0"
+      source  = "sysdiglabs/sysdig"
+      version = "~> 1.39"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/integrations/event-bridge/versions.tf
+++ b/modules/integrations/event-bridge/versions.tf
@@ -6,7 +6,8 @@ terraform {
       version = ">= 5.60.0"
     }
     sysdig = {
-      source = "sysdiglabs/sysdig"
+      source  = "local/sysdiglabs/sysdig" // TODO: remove after test
+      version = "~> 1.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/onboarding/README.md
+++ b/modules/onboarding/README.md
@@ -59,7 +59,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
 | <a name="input_account_alias"></a> [account_alias](#input\_account\_alias) | Alias name of the AWS account | `string` | `""` | no |
-| <a name="input_is_gov_cloud"></a> [is\_gov\_cloud](#input\_is\_gov\_cloud) | true/false whether secure-for-cloud should be deployed in a govcloud account/org or not | `bool` | `false` | no |
+| <a name="input_is_gov_cloud_onboarding"></a> [is\_gov\_cloud\_onboarding](#input\_is\_gov\_cloud\_onboarding) | true/false whether secure-for-cloud should be deployed in a govcloud account/org or not | `bool` | `false` | no |
 
 ## Outputs
 
@@ -68,7 +68,7 @@ No modules.
 | <a name="output_sysdig_secure_account_id"></a> [sysdig\_secure\_account\_id](#output\_sysdig\_secure\_account\_id) | ID of the Sysdig Cloud Account created |
 | <a name="output_is_organizational"></a> [is\_organizational](#output\_is\_organizational) | Boolean value to indicate if secure-for-cloud is deployed to an entire AWS organization or not |
 | <a name="output_organizational_unit_ids"></a> [organizational\_unit\_ids](#output\_organizational\_unit\_ids) | organizational unit ids onboarded |
-| <a name="output_is_gov_cloud"></a> [is\_gov\_cloud](#output\_is\_gov\_cloud) | Boolean value to indicate if the govcloud account/organization is onboarded |
+| <a name="output_is_gov_cloud_onboarding"></a> [is\_gov\_cloud\_onboarding](#output\_is\_gov\_cloud\_onboarding) | Boolean value to indicate if a govcloud account/organization is being onboarded |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/modules/onboarding/README.md
+++ b/modules/onboarding/README.md
@@ -8,7 +8,9 @@ The following resources will be created in each instrumented account:
     - `arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess` (for organizational setup)
     - An Access Policy attached to this role using a Sysdig provided `ExternalId`. 
 
-If instrumenting an AWS Organization, an `aws_cloudformation_stack_set` will be created in the Management Account. 
+If instrumenting an AWS Organization, an `aws_cloudformation_stack_set` will be created in the Management Account.
+
+If instrumenting an AWS Gov account/organization, IAM policies and resources will be created in `aws-us-gov` region.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -16,13 +18,13 @@ If instrumenting an AWS Organization, an `aws_cloudformation_stack_set` will be 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.62.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.60.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.62.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.60.0 |
 
 ## Modules
 
@@ -32,29 +34,41 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [random_id.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_iam_role.onboarding_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.onboarding_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachments_exclusive.onboarding_role_managed_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [sysdig_secure_cloud_auth_account.cloud_auth_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_auth_account) | resource |
 | [aws_cloudformation_stack_set.stackset](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
 | [aws_cloudformation_stack_set_instance.stackset_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
-| [aws_iam_role.cspm_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [sysdig_secure_organization.aws_organization](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_organization) | resource |
+| [sysdig_secure_trusted_cloud_identity.trusted_identity](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_trusted_cloud_identity) | data source |
+| [sysdig_secure_tenant_external_id.external_id](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_tenant_external_id) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_organizations_organization.org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
-| [aws_iam_policy_document.custom_resources_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_external_id"></a> [external\_id](#input\_external\_id) | Random string generated unique to a customer | `string` | n/a | yes |
-| <a name="input_trusted_identity"></a> [trusted\_identity](#input\_trusted\_identity) | The name of sysdig trusted identity | `string` | n/a | yes |
 | <a name="input_failure_tolerance_percentage"></a> [failure\_tolerance\_percentage](#input\_failure\_tolerance\_percentage) | The percentage of accounts, per Region, for which stack operations can fail before AWS CloudFormation stops the operation in that Region | `number` | `90` | no |
 | <a name="input_is_organizational"></a> [is\_organizational](#input\_is\_organizational) | true/false whether secure-for-cloud should be deployed in an organizational setup (all accounts of org) or not (only on default aws provider account) | `bool` | `false` | no |
-| <a name="input_org_units"></a> [org\_units](#input\_org\_units) | Org unit id to install cspm | `set(string)` | `[]` | no |
-| <a name="input_region"></a> [region](#input\_region) | Default region for resource creation in organization mode | `string` | `"eu-central-1"` | no |
-| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the IAM Role that will be created. | `string` | `"sysdig-secure"` | no |
+| <a name="input_organizational_unit_ids"></a> [organizational\_unit\_ids](#input\_organizational\_unit\_ids) | Org unit ids to install onboarding | `set(string)` | `[]` | no |
+| <a name="input_region"></a> [region](#input\_region) | Default region for resource creation in organization mode | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Default timeout values for create, update, and delete operations | `string` | `"30m"` | no |
+| <a name="input_account_alias"></a> [account_alias](#input\_account\_alias) | Alias name of the AWS account | `string` | `""` | no |
+| <a name="input_is_gov_cloud"></a> [is\_gov\_cloud](#input\_is\_gov\_cloud) | true/false whether secure-for-cloud should be deployed in a govcloud account/org or not | `bool` | `false` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_sysdig_secure_account_id"></a> [sysdig\_secure\_account\_id](#output\_sysdig\_secure\_account\_id) | ID of the Sysdig Cloud Account created |
+| <a name="output_is_organizational"></a> [is\_organizational](#output\_is\_organizational) | Boolean value to indicate if secure-for-cloud is deployed to an entire AWS organization or not |
+| <a name="output_organizational_unit_ids"></a> [organizational\_unit\_ids](#output\_organizational\_unit\_ids) | organizational unit ids onboarded |
+| <a name="output_is_gov_cloud"></a> [is\_gov\_cloud](#output\_is\_gov\_cloud) | Boolean value to indicate if the govcloud account/organization is onboarded |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/modules/onboarding/README.md
+++ b/modules/onboarding/README.md
@@ -19,6 +19,8 @@ If instrumenting an AWS Gov account/organization, IAM policies and resources wil
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.60.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1 |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | ~>1.39 |
 
 ## Providers
 

--- a/modules/onboarding/main.tf
+++ b/modules/onboarding/main.tf
@@ -88,7 +88,7 @@ resource "sysdig_secure_cloud_auth_account" "cloud_auth_account" {
   provider_id          = data.aws_caller_identity.current.account_id
   provider_type        = "PROVIDER_AWS"
   provider_alias       = var.account_alias
-  regulatory_framework = var.is_gov_cloud_onboarding ? "REGULATORY_FRAMEWORK_US_FEDRAMP" : ""
+  provider_partition   = var.is_gov_cloud_onboarding ? "PROVIDER_PARTITION_AWS_GOVCLOUD" : ""
 
   component {
     type     = "COMPONENT_TRUSTED_ROLE"

--- a/modules/onboarding/main.tf
+++ b/modules/onboarding/main.tf
@@ -19,8 +19,8 @@ resource "random_id" "suffix" {
 
 locals {
   onboarding_role_name = "sysdig-secure-onboarding-${random_id.suffix.hex}"
-  trusted_identity     = var.is_gov_cloud ? data.sysdig_secure_trusted_cloud_identity.trusted_identity.gov_identity : data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity
-  arn_prefix           = var.is_gov_cloud ? "arn:aws-us-gov" : "arn:aws"
+  trusted_identity     = var.is_gov_cloud_onboarding ? data.sysdig_secure_trusted_cloud_identity.trusted_identity.gov_identity : data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity
+  arn_prefix           = var.is_gov_cloud_onboarding ? "arn:aws-us-gov" : "arn:aws"
 }
 
 #----------------------------------------------------------
@@ -88,7 +88,7 @@ resource "sysdig_secure_cloud_auth_account" "cloud_auth_account" {
   provider_id          = data.aws_caller_identity.current.account_id
   provider_type        = "PROVIDER_AWS"
   provider_alias       = var.account_alias
-  regulatory_framework = var.is_gov_cloud ? "REGULATORY_FRAMEWORK_US_FEDRAMP" : ""
+  regulatory_framework = var.is_gov_cloud_onboarding ? "REGULATORY_FRAMEWORK_US_FEDRAMP" : ""
 
   component {
     type     = "COMPONENT_TRUSTED_ROLE"

--- a/modules/onboarding/organizational.tf
+++ b/modules/onboarding/organizational.tf
@@ -45,14 +45,23 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: [ ${data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity} ]
+              AWS: [ ${local.trusted_identity} ]
             Action: [ 'sts:AssumeRole' ]
             Condition:
               StringEquals:
                 sts:ExternalId: ${data.sysdig_secure_tenant_external_id.external_id.external_id}
+      Policies:
+          - PolicyName: ${local.onboarding_role_name}
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - "account:Get*"
+                    - "account:List*"
+                  Resource: "*"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/AWSAccountManagementReadOnlyAccess"
-        - "arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess"
+        - "${local.arn_prefix}:iam::aws:policy/AWSOrganizationsReadOnlyAccess"
 TEMPLATE
 }
 

--- a/modules/onboarding/outputs.tf
+++ b/modules/onboarding/outputs.tf
@@ -12,3 +12,8 @@ output "organizational_unit_ids" {
   value       = var.organizational_unit_ids
   description = "organizational unit ids to onboard"
 }
+
+output "is_gov_cloud" {
+  value       = var.is_gov_cloud
+  description = "onboard the govcloud account/organization"
+}

--- a/modules/onboarding/outputs.tf
+++ b/modules/onboarding/outputs.tf
@@ -13,7 +13,7 @@ output "organizational_unit_ids" {
   description = "organizational unit ids to onboard"
 }
 
-output "is_gov_cloud" {
-  value       = var.is_gov_cloud
+output "is_gov_cloud_onboarding" {
+  value       = var.is_gov_cloud_onboarding
   description = "onboard the govcloud account/organization"
 }

--- a/modules/onboarding/variables.tf
+++ b/modules/onboarding/variables.tf
@@ -47,7 +47,7 @@ variable "account_alias" {
   default     = ""
 }
 
-variable "is_gov_cloud" {
+variable "is_gov_cloud_onboarding" {
   type        = bool
   default     = false
   description = "true/false whether secure-for-cloud should be deployed in a govcloud account/org or not"

--- a/modules/onboarding/variables.tf
+++ b/modules/onboarding/variables.tf
@@ -47,3 +47,8 @@ variable "account_alias" {
   default     = ""
 }
 
+variable "is_gov_cloud" {
+  type        = bool
+  default     = false
+  description = "true/false whether secure-for-cloud should be deployed in a govcloud account/org or not"
+}

--- a/modules/onboarding/versions.tf
+++ b/modules/onboarding/versions.tf
@@ -10,8 +10,8 @@ terraform {
       version = ">= 3.1"
     }
     sysdig = {
-      source  = "local/sysdiglabs/sysdig" // TODO: remove after test
-      version = "~> 1.0.0"
+      source  = "sysdiglabs/sysdig"
+      version = "~> 1.39"
     }
   }
 }

--- a/modules/onboarding/versions.tf
+++ b/modules/onboarding/versions.tf
@@ -10,7 +10,8 @@ terraform {
       version = ">= 3.1"
     }
     sysdig = {
-      source = "sysdiglabs/sysdig"
+      source  = "local/sysdiglabs/sysdig" // TODO: remove after test
+      version = "~> 1.0.0"
     }
   }
 }

--- a/test/examples/organization/event_bridge_gov.tf
+++ b/test/examples/organization/event_bridge_gov.tf
@@ -9,7 +9,7 @@ module "event-bridge" {
   sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
   is_organizational        = module.onboarding.is_organizational
   org_units                = module.onboarding.organizational_unit_ids
-  is_gov_cloud             = module.onboarding.is_gov_cloud
+  is_gov_cloud_onboarding  = module.onboarding.is_gov_cloud_onboarding
 }
 
 resource "sysdig_secure_cloud_auth_account_feature" "threat_detection" {

--- a/test/examples/organization/event_bridge_gov.tf
+++ b/test/examples/organization/event_bridge_gov.tf
@@ -1,0 +1,29 @@
+#---------------------------------------------------------------------------------------------
+# Ensure installation flow for foundational onboarding has been completed before
+# installing additional Sysdig features.
+#---------------------------------------------------------------------------------------------
+
+module "event-bridge" {
+  source                   = "../../../modules/integrations/event-bridge"
+  regions                  = ["us-gov-east-1"]
+  sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
+  is_organizational        = module.onboarding.is_organizational
+  org_units                = module.onboarding.organizational_unit_ids
+  is_gov_cloud             = module.onboarding.is_gov_cloud
+}
+
+resource "sysdig_secure_cloud_auth_account_feature" "threat_detection" {
+  account_id = module.onboarding.sysdig_secure_account_id
+  type       = "FEATURE_SECURE_THREAT_DETECTION"
+  enabled    = true
+  components = [module.event-bridge.event_bridge_component_id]
+  depends_on = [module.event-bridge]
+}
+
+resource "sysdig_secure_cloud_auth_account_feature" "identity_entitlement" {
+  account_id = module.onboarding.sysdig_secure_account_id
+  type       = "FEATURE_SECURE_IDENTITY_ENTITLEMENT"
+  enabled    = true
+  components = [module.event-bridge.event_bridge_component_id]
+  depends_on = [module.event-bridge, sysdig_secure_cloud_auth_account_feature.config_posture]
+}

--- a/test/examples/organization/onboarding_with_cspm.tf
+++ b/test/examples/organization/onboarding_with_cspm.tf
@@ -18,16 +18,16 @@ provider "aws" {
 }
 
 module "onboarding" {
-  source            	  = "../../../modules/onboarding"
+  source            	    = "../../../modules/onboarding"
   organizational_unit_ids = ["ou-ks5g-dofso0kc"]
-  is_organizational 	  = true
+  is_organizational 	    = true
 }
 
 module "config-posture" {
   source                   = "../../../modules/config-posture"
-  org_units                = module.onboarding.organizational_unit_ids
-  is_organizational        = module.onboarding.is_organizational
   sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
+  org_units                = ["ou-ks5g-dofso0kc"]
+  is_organizational        = true
 }
 
 resource "sysdig_secure_cloud_auth_account_feature" "config_posture" {

--- a/test/examples/organization/onboarding_with_cspm_gov.tf
+++ b/test/examples/organization/onboarding_with_cspm_gov.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    sysdig = {
+      source  = "sysdiglabs/sysdig"
+      version = "~> 1.37"
+    }
+  }
+}
+
+provider "sysdig" {
+  sysdig_secure_url       = "https://secure-staging.sysdig.com"
+  sysdig_secure_api_token =  "<API_TOKEN>"
+}
+
+provider "aws" {
+  region              = "us-gov-east-1"
+  allowed_account_ids = ["123456789101"]
+}
+
+module "onboarding" {
+  source            	    = "../../../modules/onboarding"
+  organizational_unit_ids = ["ou-ks5g-dofso0kc"]
+  is_organizational 	    = true
+  is_gov_cloud            = true
+}
+
+module "config-posture" {
+  source                   = "../../../modules/config-posture"
+  org_units                = module.onboarding.organizational_unit_ids
+  is_organizational        = module.onboarding.is_organizational
+  sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
+  is_gov_cloud             = true
+}
+
+resource "sysdig_secure_cloud_auth_account_feature" "config_posture" {
+  account_id = module.onboarding.sysdig_secure_account_id
+  type       = "FEATURE_SECURE_CONFIG_POSTURE"
+  enabled    = true
+  components = [module.config-posture.config_posture_component_id]
+  depends_on = [module.config-posture]
+}

--- a/test/examples/organization/onboarding_with_cspm_gov.tf
+++ b/test/examples/organization/onboarding_with_cspm_gov.tf
@@ -21,15 +21,15 @@ module "onboarding" {
   source            	    = "../../../modules/onboarding"
   organizational_unit_ids = ["ou-ks5g-dofso0kc"]
   is_organizational 	    = true
-  is_gov_cloud            = true
+  is_gov_cloud_onboarding = true
 }
 
 module "config-posture" {
   source                   = "../../../modules/config-posture"
-  org_units                = module.onboarding.organizational_unit_ids
-  is_organizational        = module.onboarding.is_organizational
   sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
-  is_gov_cloud             = true
+  org_units                = ["ou-ks5g-dofso0kc"]
+  is_organizational        = true
+  is_gov_cloud_onboarding  = true
 }
 
 resource "sysdig_secure_cloud_auth_account_feature" "config_posture" {

--- a/test/examples/organization/onboarding_with_cspm_gov.tf
+++ b/test/examples/organization/onboarding_with_cspm_gov.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     sysdig = {
       source  = "sysdiglabs/sysdig"
-      version = "~> 1.37"
+      version = "~> 1.39"
     }
   }
 }

--- a/test/examples/single_account/event_bridge_gov.tf
+++ b/test/examples/single_account/event_bridge_gov.tf
@@ -7,7 +7,7 @@ module "event-bridge" {
   source                   = "../../../modules/integrations/event-bridge"
   regions                  = ["us-gov-east-1"]
   sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
-  is_gov_cloud             = module.onboarding.is_gov_cloud
+  is_gov_cloud_onboarding  = module.onboarding.is_gov_cloud_onboarding
 }
 
 resource "sysdig_secure_cloud_auth_account_feature" "threat_detection" {

--- a/test/examples/single_account/event_bridge_gov.tf
+++ b/test/examples/single_account/event_bridge_gov.tf
@@ -1,0 +1,27 @@
+#---------------------------------------------------------------------------------------------
+# Ensure installation flow for foundational onboarding has been completed before
+# installing additional Sysdig features.
+#---------------------------------------------------------------------------------------------
+
+module "event-bridge" {
+  source                   = "../../../modules/integrations/event-bridge"
+  regions                  = ["us-gov-east-1"]
+  sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
+  is_gov_cloud             = module.onboarding.is_gov_cloud
+}
+
+resource "sysdig_secure_cloud_auth_account_feature" "threat_detection" {
+  account_id = module.onboarding.sysdig_secure_account_id
+  type       = "FEATURE_SECURE_THREAT_DETECTION"
+  enabled    = true
+  components = [module.event-bridge.event_bridge_component_id]
+  depends_on = [module.event-bridge]
+}
+
+resource "sysdig_secure_cloud_auth_account_feature" "identity_entitlement" {
+  account_id = module.onboarding.sysdig_secure_account_id
+  type       = "FEATURE_SECURE_IDENTITY_ENTITLEMENT"
+  enabled    = true
+  components = [module.event-bridge.event_bridge_component_id]
+  depends_on = [module.event-bridge, sysdig_secure_cloud_auth_account_feature.config_posture]
+}

--- a/test/examples/single_account/onboarding_with_cspm_gov.tf
+++ b/test/examples/single_account/onboarding_with_cspm_gov.tf
@@ -18,14 +18,14 @@ provider "aws" {
 }
 
 module "onboarding" {
-  source            = "../../../modules/onboarding"
-  is_gov_cloud      = true
+  source                  = "../../../modules/onboarding"
+  is_gov_cloud_onboarding = true
 }
 
 module "config-posture" {
   source                   = "../../../modules/config-posture"
   sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
-  is_gov_cloud             = true
+  is_gov_cloud_onboarding  = true
 }
 
 resource "sysdig_secure_cloud_auth_account_feature" "config_posture" {

--- a/test/examples/single_account/onboarding_with_cspm_gov.tf
+++ b/test/examples/single_account/onboarding_with_cspm_gov.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    sysdig = {
+      source  = "sysdiglabs/sysdig"
+      version = "~> 1.37"
+    }
+  }
+}
+
+provider "sysdig" {
+  sysdig_secure_url       = "https://secure-staging.sysdig.com"
+  sysdig_secure_api_token =  "<API_TOKEN>"
+}
+
+provider "aws" {
+  region              = "us-gov-east-1"
+  allowed_account_ids = ["123456789101"]
+}
+
+module "onboarding" {
+  source            = "../../../modules/onboarding"
+  is_gov_cloud      = true
+}
+
+module "config-posture" {
+  source                   = "../../../modules/config-posture"
+  sysdig_secure_account_id = module.onboarding.sysdig_secure_account_id
+  is_gov_cloud             = true
+}
+
+resource "sysdig_secure_cloud_auth_account_feature" "config_posture" {
+  account_id = module.onboarding.sysdig_secure_account_id
+  type       = "FEATURE_SECURE_CONFIG_POSTURE"
+  enabled    = true
+  components = [module.config-posture.config_posture_component_id]
+  depends_on = [module.config-posture]
+}

--- a/test/examples/single_account/onboarding_with_cspm_gov.tf
+++ b/test/examples/single_account/onboarding_with_cspm_gov.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     sysdig = {
       source  = "sysdiglabs/sysdig"
-      version = "~> 1.37"
+      version = "~> 1.39"
     }
   }
 }


### PR DESCRIPTION
Change summary:
-----------------
1. Added support to install govcloud single account and org in foundational onboarding module.
2. Added same support in config-posture module.
3. Added same support in event-bridge module.
4. Updated and cleaned up the READMEs of the modules.
5. Added tests for foundational and event-bridge single and org installs.