### PR TITLE
fix(agentless-scanning): stackeset administration role

### DIFF
--- a/modules/agentless-scanning/organizational.tf
+++ b/modules/agentless-scanning/organizational.tf
@@ -40,6 +40,10 @@ resource "aws_cloudformation_stack_set" "ou_resources_stackset" {
     retain_stacks_on_account_removal = false
   }
 
+  lifecycle {
+    ignore_changes = [administration_role_arn] # https://github.com/hashicorp/terraform-provider-aws/issues/23464
+  }
+
   template_body = <<TEMPLATE
 Resources:
   ScanningRole:


### PR DESCRIPTION
* per: https://github.com/hashicorp/terraform-provider-aws/issues/23464 fixes an issue when service managed stacksets, working around an AWS provider bug