### PR TITLE
feat(agentless-scanning): add accounts list onboarding option for agentless scanning module

### DIFF
--- a/modules/agentless-scanning/README.md
+++ b/modules/agentless-scanning/README.md
@@ -37,6 +37,7 @@ No modules.
 |------|------|
 | [aws_cloudformation_stack_set.ou_resources_stackset](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
 | [aws_cloudformation_stack_set.primary_acc_stackset](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
+| [aws_cloudformation_stack_set_instance.accounts_stackset_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
 | [aws_cloudformation_stack_set_instance.ou_stackset_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
 | [aws_cloudformation_stack_set_instance.primary_acc_stackset_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set_instance) | resource |
 | [aws_iam_role.scanning_stackset_admin_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -62,6 +63,7 @@ No modules.
 | <a name="input_kms_key_deletion_window"></a> [kms\_key\_deletion\_window](#input\_kms\_key\_deletion\_window) | Deletion window for shared KMS key | `number` | `7` | no |
 | <a name="input_mgt_stackset"></a> [mgt\_stackset](#input\_mgt\_stackset) | (Optional) Indicates if the management stackset should be deployed | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the installation. Assigned to most child resource(s) | `string` | `"sysdig-secure-scanning"` | no |
+| <a name="input_org_accounts"></a> [org\_accounts](#input\_org\_accounts) | (Optional) List of Account IDs in which to setup Agentless Scanning. By default, Agentless Scanning will be setup in all accounts within the Organization. This field is ignored if `is_organizational = false`. If this field is set `org_units` variable is ignored and resources are deployed only to accounts listed within this variable with addition of management account of the organization | `set(string)` | `[]` | no |
 | <a name="input_org_units"></a> [org\_units](#input\_org\_units) | (Optional) List of Organization Unit IDs in which to setup Agentless Scanning. By default, Agentless Scanning will be setup in all accounts within the Organization. This field is ignored if `is_organizational = false` | `set(string)` | `[]` | no |
 | <a name="input_regions"></a> [regions](#input\_regions) | (Optional) List of regions in which to install Agentless Scanning | `set(string)` | `[]` | no |
 | <a name="input_scanning_account_id"></a> [scanning\_account\_id](#input\_scanning\_account\_id) | The identifier of the account that will receive volume snapshots | `string` | `"878070807337"` | no |

--- a/modules/agentless-scanning/variables.tf
+++ b/modules/agentless-scanning/variables.tf
@@ -36,6 +36,12 @@ variable "org_units" {
   default     = []
 }
 
+variable "org_accounts" {
+  description = "(Optional) List of Account IDs in which to setup Agentless Scanning. By default, Agentless Scanning will be setup in all accounts within the Organization. This field is ignored if `is_organizational = false`. If this field is set `org_units` variable is ignored and resources are deployed only to accounts listed within this variable with addition of management account of the organization"
+  type        = set(string)
+  default     = []
+}
+
 variable "regions" {
   description = "(Optional) List of regions in which to install Agentless Scanning"
   type        = set(string)


### PR DESCRIPTION
Add option to be able to onboad only specific accounts for agentless scanning module.