### PR TITLE
fix(event-bridge): add org cloudwatch permissions (SSPROD-53939)

### DIFF
--- a/modules/integrations/event-bridge/stackset_template_org_policies.tpl
+++ b/modules/integrations/event-bridge/stackset_template_org_policies.tpl
@@ -34,4 +34,5 @@ Resources:
                   Action:
                     - "events:DescribeApiDestination"
                     - "events:DescribeConnection"
+                    - "cloudwatch:GetMetricStatistics"
                   Resource: "*"


### PR DESCRIPTION
This pull request includes a small change to the `modules/integrations/event-bridge/stackset_template_org_policies.tpl` file. The change adds the `cloudwatch:GetMetricStatistics` action to the list of allowed actions under the `Resources:` section.

* [`modules/integrations/event-bridge/stackset_template_org_policies.tpl`](diffhunk://#diff-dc9a9994425e9b6d394ca5029f5e76158ec50ec51dec2bc8c8e9f37bd52dd08cR37): Added `cloudwatch:GetMetricStatistics` to the list of allowed actions.