### PR TITLE
feat(onboarding): Avoid recreating stacksets when new OUs to include

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ There are four new parameters to configure organizational deployments on the clo
 
 **WARNING**: module variable `organizational_unit_ids` / `org_units` will be DEPRECATED soon going forward. Please work with Sysdig to migrate your Terraform installs to use `include_ouids` instead to achieve the same deployment outcome.
 
+### Stackset Instances Installation
+
+If new OUs are added in the Include OUIDs list, the existing stackset instances will not get recreated and TF will only create the stackset instances for the newly added OUs.
+
+**Note**: This applies to only OUs added/removed to/from the organizational configuration. If accounts are added/removed from the Exclude Accounts or Include Extra Accounts list, it will end up recreating the stackset instances.
+
+<br/>
+
 ## Best practices
 
 For contributing to existing modules or adding new modules, below are some of the best practices recommended :-

--- a/modules/config-posture/organizational.tf
+++ b/modules/config-posture/organizational.tf
@@ -76,12 +76,12 @@ TEMPLATE
 }
 
 resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
-  count = var.is_organizational ? 1 : 0
+  for_each = var.is_organizational ? toset(local.deployment_targets_org_units) : []
 
   region         = var.region == "" ? null : var.region
   stack_set_name = aws_cloudformation_stack_set.stackset[0].name
   deployment_targets {
-    organizational_unit_ids = local.deployment_targets_org_units
+    organizational_unit_ids = [each.value]
     accounts                = local.check_old_ouid_param ? null : (local.deployment_targets_accounts_filter == "NONE" ? null : local.deployment_targets_accounts.accounts_to_deploy)
     account_filter_type     = local.check_old_ouid_param ? null : local.deployment_targets_accounts_filter
   }

--- a/modules/onboarding/organizational.tf
+++ b/modules/onboarding/organizational.tf
@@ -54,12 +54,12 @@ TEMPLATE
 }
 
 resource "aws_cloudformation_stack_set_instance" "stackset_instance" {
-  count = var.is_organizational ? 1 : 0
+  for_each = var.is_organizational ? toset(local.deployment_targets_org_units) : []
 
   region         = var.region == "" ? null : var.region
   stack_set_name = aws_cloudformation_stack_set.stackset[0].name
   deployment_targets {
-    organizational_unit_ids = local.deployment_targets_org_units
+    organizational_unit_ids = [each.value]
     accounts                = local.check_old_ouid_param ? null : (local.deployment_targets_accounts_filter == "NONE" ? null : local.deployment_targets_accounts.accounts_to_deploy)
     account_filter_type     = local.check_old_ouid_param ? null : local.deployment_targets_accounts_filter
   }

--- a/modules/vm-workload-scanning/organizational.tf
+++ b/modules/vm-workload-scanning/organizational.tf
@@ -120,11 +120,11 @@ resource "aws_cloudformation_stack_set" "scanning_role_stackset" {
 
 # stackset instance to deploy agentless scanning role, in all organization units
 resource "aws_cloudformation_stack_set_instance" "scanning_role_stackset_instance" {
-  count = var.is_organizational ? 1 : 0
+  for_each = var.is_organizational ? toset(local.deployment_targets_org_units) : []
 
   stack_set_name = aws_cloudformation_stack_set.scanning_role_stackset[0].name
   deployment_targets {
-    organizational_unit_ids = local.deployment_targets_org_units
+    organizational_unit_ids = [each.value]
     accounts                = local.check_old_ouid_param ? null : (local.deployment_targets_accounts_filter == "NONE" ? null : local.deployment_targets_accounts.accounts_to_deploy)
     account_filter_type     = local.check_old_ouid_param ? null : local.deployment_targets_accounts_filter
   }


### PR DESCRIPTION
Change summary:
--------------------
- Whenever any OUs are added/removed from the included OUs list, this will avoid recreating existing stacksets.
- This is a copy of @maratsal 's [PR](https://github.com/sysdiglabs/terraform-aws-secure/pull/41) on top of recent changes.
- Updated README to mention the limitation.