### PR TITLE
bugfix(log ingestion/S3) - SNS provider change revert

### DIFF
--- a/modules/integrations/cloud-logs/README.md
+++ b/modules/integrations/cloud-logs/README.md
@@ -25,6 +25,16 @@ Additional features include:
 - Support for AWS GovCloud deployments
 - Support for cross-region deployments where the S3 bucket and SNS topic are in different regions
 
+## Important Note - AWS provider
+
+This module relies on a secondary AWS provider, with alias `sns`. We require this additional provider to support cross-region deployments where the SNS topic is defined or to be created in a different region. If you don't intend to use a different region you can define if before including the module in your setup as:
+```
+provider aws {
+  alias  = "sns"
+  region = data.aws_region.current.name
+}
+```
+
 ## Important Notes for Cross-Account Access
 
 When using this module with organizational cross-account access (where CloudTrail bucket is in a different AWS account), the module automatically deploys a StackSet to configure the role in the bucket account.

--- a/modules/integrations/cloud-logs/main.tf
+++ b/modules/integrations/cloud-logs/main.tf
@@ -170,21 +170,16 @@ data "aws_iam_policy_document" "cloudlogs_s3_access" {
 #-----------------------------------------------------------------------------------------------------------------------
 # SNS Topic and Subscription for CloudTrail notifications
 #-----------------------------------------------------------------------------------------------------------------------
-provider aws {
-  alias = "sns_default"
-  region = local.topic_region
-}
-
 resource "aws_sns_topic" "cloudtrail_notifications" {
   count = var.create_topic ? 1 : 0
-  provider = try(aws.sns, aws.sns_default)
+  provider = aws.sns
   name  = local.topic_name
   tags  = var.tags
 }
 
 resource "aws_sns_topic_policy" "cloudtrail_notifications" {
   count = var.create_topic ? 1 : 0
-  provider = try(aws.sns, aws.sns_default)
+  provider = aws.sns
   arn   = aws_sns_topic.cloudtrail_notifications[0].arn
   policy = jsonencode({
     Version = "2012-10-17"
@@ -205,7 +200,7 @@ resource "aws_sns_topic_policy" "cloudtrail_notifications" {
 resource "aws_sns_topic_subscription" "cloudtrail_notifications" {
   count = !local.is_cross_account_topic ? 1 : 0
   topic_arn = var.topic_arn
-  provider = try(aws.sns, aws.sns_default)
+  provider = aws.sns
   protocol  = "https"
   endpoint  = local.ingestion_url
 


### PR DESCRIPTION
The latest change to the SNS provider led to an invalid module.
Revert it and make the provider be supplied from the outside