### PR TITLE
fix(cross-account event bridge):add cloud provider param in cling assets (SSPROD-59763)

### DIFF
--- a/modules/integrations/cross-account-event-bridge/main.tf
+++ b/modules/integrations/cross-account-event-bridge/main.tf
@@ -14,7 +14,9 @@
 #-----------------------------------------------------------------------------------------
 data "aws_caller_identity" "current" {}
 
-data "sysdig_secure_cloud_ingestion_assets" "assets" {}
+data "sysdig_secure_cloud_ingestion_assets" "assets" {
+  cloud_provider     = "aws"
+}
 
 data "sysdig_secure_trusted_cloud_identity" "trusted_identity" {
   cloud_provider = "aws"


### PR DESCRIPTION
This pull request introduces a small change to the `modules/integrations/cross-account-event-bridge/main.tf` file, specifying the `cloud_provider` attribute for the `sysdig_secure_cloud_ingestion_assets` data source.

* Added `cloud_provider = "aws"` to the `sysdig_secure_cloud_ingestion_assets` data block to explicitly set the cloud provider.