### PR TITLE
fix(Onboarding): Change lambda function for workload scanning modules SSPROD-69028

### DIFF
--- a/modules/vm-workload-scanning/main.tf
+++ b/modules/vm-workload-scanning/main.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "functions" {
       "lambda:GetFunctionConfiguration",
       "lambda:GetRuntimeManagementConfig",
       "lambda:ListFunctions",
-      "lambda:ListTagsForResource",
+      "lambda:ListTags",
       "lambda:GetLayerVersionByArn",
       "lambda:GetLayerVersion",
       "lambda:ListLayers",

--- a/modules/vm-workload-scanning/organizational.tf
+++ b/modules/vm-workload-scanning/organizational.tf
@@ -74,7 +74,7 @@ Resources:
                     - "lambda:GetFunctionConfiguration"
                     - "lambda:GetRuntimeManagementConfig"
                     - "lambda:ListFunctions"
-                    - "lambda:ListTagsForResource"
+                    - "lambda:ListTags"
                     - "lambda:GetLayerVersionByArn"
                     - "lambda:GetLayerVersion"
                     - "lambda:ListLayers"


### PR DESCRIPTION
### Jira

https://sysdig.atlassian.net/browse/SSPROD-69028

### Summary
  
  Replaces the `lambda:ListTagsForResource` IAM action with `lambda:ListTags` in the vm-workload-scanning module.

### Changes

  - `modules/vm-workload-scanning/main.tf` — updated the functions IAM policy document (single-account install / management account in org installs).
  - `modules/vm-workload-scanning/organizational.tf` — updated the CloudFormation StackSet policy template (member accounts in org installs).

  Both files were changed together to keep the single-account and organizational deployment paths consistent, since the policy in main.tf is gated only by lambda_scanning_enabled and runs in both modes.

### Notes
  
  - The unrelated `logs:ListTagsForResource` action in the response-actions module was intentionally left untouched (different AWS service).
  - No version constraints, docs, or tests reference the action, so no other files required updates.
  - A new tagged release is required for this permission change to reach module consumers.